### PR TITLE
Bugfix/use accept header

### DIFF
--- a/examples/Umbraco.AuthorizedServices.TestSite/Controllers/TestAuthorizedServicesController.cs
+++ b/examples/Umbraco.AuthorizedServices.TestSite/Controllers/TestAuthorizedServicesController.cs
@@ -86,5 +86,19 @@ public class TestAuthorizedServicesController : UmbracoApiController
 
         return Content(response);
     }
+
+    public async Task<IActionResult> GetAssetsFromAssetBank(string assetIds)
+    {
+        AssetBankSearchResponse? response = await _authorizedServiceCaller.GetRequestAsync<AssetBankSearchResponse>(
+            "assetBank",
+            "/assetbank-rya-assets-test/rest/asset-search?assetIds=" + assetIds);
+
+        if (response == null)
+        {
+            return Problem("Could not retrieve assets.");
+        }
+
+        return Content(string.Join(", ", response.Select(x => x.ToString())));
+    }
 }
 

--- a/examples/Umbraco.AuthorizedServices.TestSite/Models/ServiceResponses/AssetBankSearchResponse.cs
+++ b/examples/Umbraco.AuthorizedServices.TestSite/Models/ServiceResponses/AssetBankSearchResponse.cs
@@ -1,0 +1,20 @@
+using System.Text.Json.Serialization;
+
+namespace Umbraco.AuthorizedServices.TestSite.Models.ServiceResponses;
+
+public class AssetBankSearchResponse : List<AssetBankAsset>
+{
+}
+
+public class AssetBankAsset
+{
+    public int Id { get; set; }
+
+    [JsonPropertyName("originalFilename")]
+    public string OriginalFileName { get; set; } = string.Empty;
+
+    public override string ToString() => $"{OriginalFileName} ({Id})";
+}
+
+
+

--- a/examples/Umbraco.AuthorizedServices.TestSite/appsettings-schema.Umbraco.AuthorizedServices.json
+++ b/examples/Umbraco.AuthorizedServices.TestSite/appsettings-schema.Umbraco.AuthorizedServices.json
@@ -64,7 +64,7 @@
         },
         "AuthorizationUrlRequiresRedirectUrl": {
           "type": "boolean",
-          "description": "Gets or sets the path for requests for working with service tokens."
+          "description": "Gets or sets a value indicating whether authorization requests require sending the redirect URL."
         },
         "RequestTokenPath": {
           "type": "string",
@@ -73,6 +73,14 @@
         "RequestTokenFormat": {
           "type": "string",
           "description": "Gets or sets the format to use for encoding the request for a token."
+        },
+        "JsonSerializer": {
+          "type": "string",
+          "description": "Gets or sets the JSON serializer to use when building requests and deserializing responses."
+        },
+        "AuthorizationRequestRequiresAuthorizationHeaderWithBasicToken": {
+          "type": "boolean",
+          "description": "Gets or sets a value indicating whether the basic token should be included in the token request."
         },
         "ClientId": {
           "type": "string",

--- a/examples/Umbraco.AuthorizedServices.TestSite/appsettings.json
+++ b/examples/Umbraco.AuthorizedServices.TestSite/appsettings.json
@@ -27,6 +27,22 @@
       "TokenEncryptionKey": "",
       "Services": [
         {
+          "Alias": "assetBank",
+          "DisplayName": "Asset Bank",
+          "ApiHost": "https://rya-assets-test.assetbank-server.com",
+          "IdentityHost": "https://rya-assets-test.assetbank-server.com",
+          "TokenHost": "https://rya-assets-test.assetbank-server.com",
+          "RequestIdentityPath": "/assetbank-rya-assets-test/oauth/authorize",
+          "AuthorizationUrlRequiresRedirectUrl": true,
+          "RequestTokenPath": "/assetbank-rya-assets-test/oauth/token",
+          "RequestTokenFormat": "FormUrlEncoded",
+          "JsonSerializer": "SystemTextJson",
+          "ClientId": "",
+          "ClientSecret": "",
+          "Scopes": "",
+          "SampleRequest": "/assetbank-rya-assets-test/rest/asset-search?assetIds=28039"
+        },
+        {
           "Alias": "github",
           "DisplayName": "GitHub",
           "ApiHost": "https://api.github.com",

--- a/src/Umbraco.AuthorizedServices/Services/Implement/AuthorizedRequestBuilder.cs
+++ b/src/Umbraco.AuthorizedServices/Services/Implement/AuthorizedRequestBuilder.cs
@@ -29,6 +29,7 @@ internal sealed class AuthorizedRequestBuilder : IAuthorizedRequestBuilder
 
         requestMessage.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token.AccessToken);
         requestMessage.Headers.UserAgent.Add(new ProductInfoHeaderValue("UmbracoServiceIntegration", "1.0.0"));
+        requestMessage.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
         return requestMessage;
     }
 

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "assemblyVersion": {
     "precision": "build"
   },


### PR DESCRIPTION
Include an Accept header by default to request JSON responses.

Some services (e.g. Asset Bank) will return XML unless this is specified.