### PR TITLE
Added package Id to package manifest.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,18 +2,10 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <LangVersion>latest</LangVersion>
-    <Company>Umbraco HQ</Company>
-    <Authors>Umbraco</Authors>
-    <Copyright>Copyright © Umbraco $([System.DateTime]::Today.ToString('yyyy'))</Copyright>
-    <Product>Umbraco Authorized Services</Product>
-    <PackageProjectUrl>https://github.com/umbraco/Umbraco.AuthorizedServices</PackageProjectUrl>
-	  <RepositoryUrl>https://github.com/umbraco/Umbraco.AuthorizedServices</RepositoryUrl>
-    <PackageIcon>icon.png</PackageIcon>
     <Nullable>enable</Nullable>
     <WarningsAsErrors>Nullable</WarningsAsErrors>
     <ImplicitUsings>enable</ImplicitUsings>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <PackageReadmeFile>NuGetReadMe.md</PackageReadmeFile>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -30,11 +22,6 @@
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.435" PrivateAssets="all" IsImplicitlyDefined="true" />
     <PackageReference Include="Umbraco.Code" Version="2.0.0" PrivateAssets="all" IsImplicitlyDefined="true" />
     <PackageReference Include="Umbraco.GitVersioning.Extensions" Version="0.2.0" PrivateAssets="all" IsImplicitlyDefined="true" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Content Include="$(MSBuildThisFileDirectory)icon.png" Pack="true" PackagePath="" Visible="false" />
-    <None Include="docs\NuGetReadMe.md" Pack="true" PackagePath="\"/>
   </ItemGroup>
 
   <PropertyGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,10 +6,11 @@
     <WarningsAsErrors>Nullable</WarningsAsErrors>
     <ImplicitUsings>enable</ImplicitUsings>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageIcon>icon.png</PackageIcon>
   </PropertyGroup>
 
   <PropertyGroup>
-    <!-- TODO: Enable when final version is shipped (because there's currently no previous version) -->
+    <!-- TODO: Enable when 1.0 version is shipped -->
     <EnablePackageValidation>false</EnablePackageValidation>
     <PackageValidationBaselineVersion>1.0.0</PackageValidationBaselineVersion>
     <EnableStrictModeForCompatibleFrameworksInPackage>true</EnableStrictModeForCompatibleFrameworksInPackage>
@@ -27,4 +28,8 @@
   <PropertyGroup>
     <GitVersionBaseDirectory>$(MSBuildThisFileDirectory)</GitVersionBaseDirectory>
   </PropertyGroup>
+
+  <ItemGroup>
+    <Content Include="$(MSBuildThisFileDirectory)icon.png" Pack="true" PackagePath="" Visible="false" />
+  </ItemGroup>
 </Project>

--- a/examples/Umbraco.AuthorizedServices.TestSite/Umbraco.AuthorizedServices.TestSite.csproj
+++ b/examples/Umbraco.AuthorizedServices.TestSite/Umbraco.AuthorizedServices.TestSite.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Umbraco.Cms" Version="11.2.0" />
+    <PackageReference Include="Umbraco.Cms" Version="12.0.1" />
   </ItemGroup>
 
   <Import Project="..\..\src\Umbraco.AuthorizedServices\buildTransitive\Umbraco.AuthorizedServices.targets" />

--- a/src/Umbraco.AuthorizedServices/Constants.cs
+++ b/src/Umbraco.AuthorizedServices/Constants.cs
@@ -6,6 +6,8 @@ namespace Umbraco.AuthorizedServices;
 
 public static class Constants
 {
+    internal const string PackageId = "Umbraco.AuthorizedServices";
+
     internal const string PackageName = "Umbraco Authorized Services";
 
     public const string PluginName = "UmbracoAuthorizedServices";

--- a/src/Umbraco.AuthorizedServices/Helpers/ReflectionHelper.cs
+++ b/src/Umbraco.AuthorizedServices/Helpers/ReflectionHelper.cs
@@ -1,0 +1,66 @@
+using System.Reflection;
+
+namespace Umbraco.AuthorizedServices.Helpers;
+
+internal static class ReflectionHelper
+{
+    /// <summary>
+    /// Gets a property value by reflection. If the property does not exist, a default value is returned.
+    /// </summary>
+    /// <typeparam name="T">Object type.</typeparam>
+    /// <param name="obj">Object from which to get property value.</param>
+    /// <param name="propertyName">Name of property.</param>
+    /// <param name="defaultValue">Default value to use if property not available.</param>
+    /// <remarks>
+    /// This is used for accessing properties added in a supported version of Umbraco that's later than the
+    /// one we take a dependency on.
+    /// </remarks>
+    /// <returns>The property value, or the default.</returns>
+    public static T GetOptionalPropertyValue<T>(this object obj, string propertyName, T defaultValue)
+    {
+        PropertyInfo? propertyInfo = GetPropertyInfo(obj, propertyName);
+        if (propertyInfo == null || !propertyInfo.CanRead)
+        {
+            return defaultValue;
+        }
+
+        var value = propertyInfo.GetValue(obj, null);
+        if (value == null)
+        {
+            return defaultValue;
+        }
+
+        if (value is T t)
+        {
+            return t;
+        }
+
+        return defaultValue;
+    }
+
+    /// <summary>
+    /// Sets a property value by reflection. If the property does not exist, no exception is thrown.
+    /// </summary>
+    /// <typeparam name="T">Object type.</typeparam>
+    /// <param name="obj">Object on which to set property value.</param>
+    /// <param name="propertyName">Name of property.</param>
+    /// <param name="value">Value to set.</param>
+    /// <remarks>
+    /// See notes on <see cref="GetOptionalPropertyValue{T}(object, string, T)"/>
+    /// </remarks>
+    public static void SetOptionalPropertyValue<T>(this object obj, string propertyName, T value)
+    {
+        PropertyInfo? propertyInfo = GetPropertyInfo(obj, propertyName);
+        if (propertyInfo == null || !propertyInfo.CanWrite)
+        {
+            return;
+        }
+
+        if (propertyInfo.PropertyType.IsAssignableFrom(typeof(T)))
+        {
+            propertyInfo.SetValue(obj, value, null);
+        }
+    }
+
+    private static PropertyInfo? GetPropertyInfo(object obj, string propertyName) => obj.GetType().GetProperty(propertyName, BindingFlags.Public | BindingFlags.Instance);
+}

--- a/src/Umbraco.AuthorizedServices/Manifests/AuthorizedServicesManifestFilter.cs
+++ b/src/Umbraco.AuthorizedServices/Manifests/AuthorizedServicesManifestFilter.cs
@@ -23,6 +23,10 @@ public class AuthorizedServicesManifestFilter : IManifestFilter
             }
         };
 
+        // The PackageId property was added in Umbraco 12, so we have to use reflection here to set it if available
+        // as the package depdendency is on Umbraco 10.
+        // If and when we release a version with a depdendency on 12+, this should be removed and replaced with
+        // a standard property setter.
         ReflectionHelper.SetOptionalPropertyValue(manifest, "PackageId", Constants.PackageId);
 
         manifests.Add(manifest);

--- a/src/Umbraco.AuthorizedServices/Manifests/AuthorizedServicesManifestFilter.cs
+++ b/src/Umbraco.AuthorizedServices/Manifests/AuthorizedServicesManifestFilter.cs
@@ -1,3 +1,4 @@
+using Umbraco.AuthorizedServices.Helpers;
 using Umbraco.Cms.Core.Manifest;
 
 namespace Umbraco.AuthorizedServices.Manifests;
@@ -6,7 +7,7 @@ public class AuthorizedServicesManifestFilter : IManifestFilter
 {
     public void Filter(List<PackageManifest> manifests)
     {
-        manifests.Add(new PackageManifest
+        var manifest = new PackageManifest
         {
             AllowPackageTelemetry = true,
             Version = Constants.InformationalVersion,
@@ -20,6 +21,10 @@ public class AuthorizedServicesManifestFilter : IManifestFilter
             {
                 "/App_Plugins/UmbracoAuthorizedServices/css/style.css"
             }
-        });
+        };
+
+        ReflectionHelper.SetOptionalPropertyValue(manifest, "PackageId", Constants.PackageId);
+
+        manifests.Add(manifest);
     }
 }

--- a/src/Umbraco.AuthorizedServices/Umbraco.AuthorizedServices.csproj
+++ b/src/Umbraco.AuthorizedServices/Umbraco.AuthorizedServices.csproj
@@ -4,12 +4,20 @@
     <Description>
       Authorized Services is an extension from Umbraco intended to get you up to speed quickly with integrating external services. It handles the authentication and authorization flow for services using OAuth.
     </Description>
+    <Company>Umbraco HQ</Company>
+    <Authors>Umbraco</Authors>
+    <Copyright>Copyright © Umbraco $([System.DateTime]::Today.ToString('yyyy'))</Copyright>
+    <Product>Umbraco Authorized Services</Product>
+    <PackageProjectUrl>https://github.com/umbraco/Umbraco.AuthorizedServices</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/umbraco/Umbraco.AuthorizedServices</RepositoryUrl>
     <PackageTags>umbraco umbraco-marketplace</PackageTags>
     <StaticWebAssetBasePath>App_Plugins/UmbracoAuthorizedServices</StaticWebAssetBasePath>
+    <PackageIcon>icon.png</PackageIcon>
+    <PackageReadmeFile>NuGetReadMe.md</PackageReadmeFile>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Umbraco.Cms.Web.BackOffice" Version="[10.0, 12]" />
+    <PackageReference Include="Umbraco.Cms.Web.BackOffice" Version="[10.0, 13)" />
   </ItemGroup>
 
   <ItemGroup>
@@ -21,6 +29,11 @@
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
       <_Parameter1>Umbraco.AuthorizedServices.Tests</_Parameter1>
     </AssemblyAttribute>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="$(MSBuildThisFileDirectory)icon.png" Pack="true" PackagePath="" Visible="false" />
+    <None Include="docs\NuGetReadMe.md" Pack="true" PackagePath="\"/>
   </ItemGroup>
 
   <!-- Build client assets using NPM -->

--- a/src/Umbraco.AuthorizedServices/Umbraco.AuthorizedServices.csproj
+++ b/src/Umbraco.AuthorizedServices/Umbraco.AuthorizedServices.csproj
@@ -12,7 +12,6 @@
     <RepositoryUrl>https://github.com/umbraco/Umbraco.AuthorizedServices</RepositoryUrl>
     <PackageTags>umbraco umbraco-marketplace</PackageTags>
     <StaticWebAssetBasePath>App_Plugins/UmbracoAuthorizedServices</StaticWebAssetBasePath>
-    <PackageIcon>icon.png</PackageIcon>
     <PackageReadmeFile>NuGetReadMe.md</PackageReadmeFile>
   </PropertyGroup>
 
@@ -32,7 +31,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Content Include="$(MSBuildThisFileDirectory)icon.png" Pack="true" PackagePath="" Visible="false" />
     <None Include="docs\NuGetReadMe.md" Pack="true" PackagePath="\"/>
   </ItemGroup>
 

--- a/tests/Umbraco.AuthorizedServices.Tests/Helpers/ReflectionUtilityTests.cs
+++ b/tests/Umbraco.AuthorizedServices.Tests/Helpers/ReflectionUtilityTests.cs
@@ -1,0 +1,65 @@
+using Umbraco.AuthorizedServices.Helpers;
+
+namespace Umbraco.AuthorizedServices.Tests.Helpers;
+
+[TestFixture]
+internal class ReflectionHelperTests
+{
+    [Test]
+    public void GetOptionalPropertyValue_WithPropertyFound_ReturnsPropertyuValue()
+    {
+        var obj = new TestClass
+        {
+            TestStringProperty = "test",
+            TestIntProperty = 99,
+            TestBoolProperty = true,
+        };
+        var value1 = obj.GetOptionalPropertyValue("TestStringProperty", string.Empty);
+        var value2 = obj.GetOptionalPropertyValue("TestIntProperty", 0);
+        var value3 = obj.GetOptionalPropertyValue("TestBoolProperty", false);
+
+        Assert.AreEqual("test", value1);
+        Assert.AreEqual(99, value2);
+        Assert.True(value3);
+    }
+
+    [Test]
+    public void GetOptionalPropertyValue_WithPropertyNotFound_ReturnsDefaultValue()
+    {
+        var obj = new TestClass
+        {
+            TestStringProperty = "test",
+            TestIntProperty = 99,
+            TestBoolProperty = true
+        };
+        var value1 = obj.GetOptionalPropertyValue("MissingStringProperty", "default");
+        var value2 = obj.GetOptionalPropertyValue("MissingIntProperty", 10);
+        var value3 = obj.GetOptionalPropertyValue("MissingBoolProperty", false);
+
+        Assert.AreEqual("default", value1);
+        Assert.AreEqual(10, value2);
+        Assert.False(value3);
+    }
+
+    [Test]
+    public void SetOptionalPropertyValue_WithPropertyFound_SetsValues()
+    {
+        var obj = new TestClass();
+        obj.SetOptionalPropertyValue("TestStringProperty", "test");
+        obj.SetOptionalPropertyValue("TestIntProperty", 99);
+        obj.SetOptionalPropertyValue("TestBoolProperty", true);
+
+        Assert.AreEqual("test", obj.TestStringProperty);
+        Assert.AreEqual(99, obj.TestIntProperty);
+        Assert.True(obj.TestBoolProperty);
+    }
+
+    private class TestClass
+    {
+        public string TestStringProperty { get; set; } = string.Empty;
+
+        public int TestIntProperty { get; set; }
+
+        public bool TestBoolProperty { get; set; }
+    }
+}


### PR DESCRIPTION
This PR adds the package ID to the package manifest, using reflection so we can keep the package dependency on Umbraco 10.

Also tidied up the `.cspoj` and `.props` files so we don't have values in the test project that aren't needed there (mainly the reference to the non-existing readme file).