### PR TITLE
Feature/api key support

### DIFF
--- a/examples/Umbraco.AuthorizedServices.TestSite/Controllers/TestAuthorizedServicesController.cs
+++ b/examples/Umbraco.AuthorizedServices.TestSite/Controllers/TestAuthorizedServicesController.cs
@@ -111,10 +111,10 @@ public class TestAuthorizedServicesController : UmbracoApiController
         return Content(response);
     }
 
-    public async Task<IActionResult> GetApiKey(string serviceAlias)
+    public IActionResult GetApiKey(string serviceAlias)
     {
-        var apiKey = await _authorizedServiceCaller.GetApiKeyAsync(serviceAlias);
-        return Content(apiKey);
+        var apiKey = _authorizedServiceCaller.GetApiKey(serviceAlias);
+        return Content(apiKey ?? string.Empty);
     }
 }
 

--- a/examples/Umbraco.AuthorizedServices.TestSite/Controllers/TestAuthorizedServicesController.cs
+++ b/examples/Umbraco.AuthorizedServices.TestSite/Controllers/TestAuthorizedServicesController.cs
@@ -110,5 +110,11 @@ public class TestAuthorizedServicesController : UmbracoApiController
 
         return Content(response);
     }
+
+    public async Task<IActionResult> GetApiKey(string serviceAlias)
+    {
+        var apiKey = await _authorizedServiceCaller.GetApiKeyAsync(serviceAlias);
+        return Content(apiKey);
+    }
 }
 

--- a/examples/Umbraco.AuthorizedServices.TestSite/Controllers/TestAuthorizedServicesController.cs
+++ b/examples/Umbraco.AuthorizedServices.TestSite/Controllers/TestAuthorizedServicesController.cs
@@ -100,5 +100,15 @@ public class TestAuthorizedServicesController : UmbracoApiController
 
         return Content(string.Join(", ", response.Select(x => x.ToString())));
     }
+
+    public async Task<IActionResult> GetVideoDetailsFromYouTube()
+    {
+        var response = await _authorizedServiceCaller.SendRequestRawAsync(
+            "youtube",
+            "/v3/videos?id=[video_id]&part=snippet,contentDetails,statistics,status",
+            HttpMethod.Get);
+
+        return Content(response);
+    }
 }
 

--- a/examples/Umbraco.AuthorizedServices.TestSite/appsettings.json
+++ b/examples/Umbraco.AuthorizedServices.TestSite/appsettings.json
@@ -432,7 +432,7 @@
           "RequestIdentityPath": "",
           "RequestTokenPath": "",
           "RequestTokenFormat": "",
-          "ApiKey": "AIzaSyAxioCCVDafxefGpDoGsBLYyRAposKT42g",
+          "ApiKey: "[api_key]",
           "ApiKeyProvision": {
             "Method": "QueryString",
             "Key": "key"

--- a/examples/Umbraco.AuthorizedServices.TestSite/appsettings.json
+++ b/examples/Umbraco.AuthorizedServices.TestSite/appsettings.json
@@ -422,6 +422,25 @@
           "ClientSecret": "",
           "Scopes": "",
           "SampleRequest": "/1.1/accounts"
+        },
+        "youtube": {
+          "DisplayName": "YouTube",
+          "AuthenticationMethod": "ApiKey",
+          "ApiHost": "https://www.googleapis.com/youtube",
+          "IdentityHost": "",
+          "TokenHost": "",
+          "RequestIdentityPath": "",
+          "RequestTokenPath": "",
+          "RequestTokenFormat": "",
+          "ApiKey": "AIzaSyAxioCCVDafxefGpDoGsBLYyRAposKT42g",
+          "ApiKeyProvision": {
+            "Method": "QueryString",
+            "Key": "key"
+          },
+          "ClientId": "",
+          "ClientSecret": "",
+          "Scopes": "",
+          "SampleRequest": "/v3/videos?id=[video_id]&part=snippet,contentDetails,statistics,status"
         }
       }
     }

--- a/src/Umbraco.AuthorizedServices/ClientApp/src/backoffice/AuthorizedServices/edit.html
+++ b/src/Umbraco.AuthorizedServices/ClientApp/src/backoffice/AuthorizedServices/edit.html
@@ -24,7 +24,8 @@
                             action="vm.sendSampleRequest()"
                             type="button"
                             label="Verify Sample Request"></umb-button>
-                <umb-button action="vm.revokeAccess()"
+                <umb-button ng-if="vm.authorizationUrl.length > 0"
+                            action="vm.revokeAccess()"
                             type="button"
                             button-style="danger"
                             label="Revoke Access"></umb-button>

--- a/src/Umbraco.AuthorizedServices/Configuration/AuthorizedServiceSettings.cs
+++ b/src/Umbraco.AuthorizedServices/Configuration/AuthorizedServiceSettings.cs
@@ -33,6 +33,25 @@ public enum JsonSerializerOption
 }
 
 /// <summary>
+/// Defines the available authentication methods.
+/// </summary>
+public enum AuthenticationMethod
+{
+    OAuth1,
+    OAuth2,
+    ApiKey
+}
+
+/// <summary>
+/// Defines the available options for passing the API key with the request.
+/// </summary>
+public enum ApiKeyProvisionMethod
+{
+    HttpHeader,
+    QueryString
+}
+
+/// <summary>
 /// Defines the strongly typed configuration model.
 /// </summary>
 public class AuthorizedServiceSettings
@@ -40,6 +59,18 @@ public class AuthorizedServiceSettings
     public string TokenEncryptionKey { get; set; } = string.Empty;
 
     public IDictionary<string, ServiceSummary> Services { get; set; } = new Dictionary<string, ServiceSummary>();
+}
+
+/// <summary>
+/// Defines the provisioning options for an API key based authentication.
+/// </summary>
+public class ApiKeyProvision
+{
+    public ApiKeyProvisionMethod Method { get; set; }
+
+    public string Key { get; set; } = string.Empty;
+
+    public override string ToString() => $"{Method} / {Key}";
 }
 
 /// <summary>
@@ -66,6 +97,11 @@ public class ServiceSummary
 /// <inheritdoc />
 public class ServiceDetail : ServiceSummary
 {
+    /// <summary>
+    /// Gets or sets the authentication method for the service.
+    /// </summary>
+    public AuthenticationMethod AuthenticationMethod { get; set; } = AuthenticationMethod.OAuth2;
+
     /// <summary>
     /// Gets or sets the host name for the service's API.
     /// </summary>
@@ -99,7 +135,7 @@ public class ServiceDetail : ServiceSummary
     /// <summary>
     /// Gets or sets the format to use for encoding the request for a token.
     /// </summary>
-    public TokenRequestContentFormat RequestTokenFormat { get; set; } = TokenRequestContentFormat.Querystring;
+    public TokenRequestContentFormat? RequestTokenFormat { get; set; }
 
     /// <summary>
     /// Gets or sets the JSON serializer to use when building requests and deserializing responses.
@@ -110,6 +146,16 @@ public class ServiceDetail : ServiceSummary
     /// Gets or sets a value indicating whether the basic token should be included in the token request.
     /// </summary>
     public bool AuthorizationRequestRequiresAuthorizationHeaderWithBasicToken { get; set; } = false;
+
+    /// <summary>
+    /// Gets or sets the API Key for the service.
+    /// </summary>
+    public string ApiKey { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the provisioning options for an API key based authentication.
+    /// </summary>
+    public ApiKeyProvision? ApiKeyProvision { get; set; }
 
     /// <summary>
     /// Gets or sets the client Id for the app registered with the service.

--- a/src/Umbraco.AuthorizedServices/Controllers/AuthorizedServiceController.cs
+++ b/src/Umbraco.AuthorizedServices/Controllers/AuthorizedServiceController.cs
@@ -57,9 +57,7 @@ public class AuthorizedServiceController : BackOfficeNotificationsController
         string? authorizationUrl = null;
         if (serviceDetail.AuthenticationMethod == AuthenticationMethod.OAuth2)
         {
-            bool tokenExists = _tokenStorage.GetToken(alias) != null;
-
-            if (!tokenExists)
+            if (!isAuthorized)
             {
                 AuthorizationPayload authorizationPayload = _authorizedServiceAuthorizationPayloadBuilder.BuildPayload();
 

--- a/src/Umbraco.AuthorizedServices/Controllers/AuthorizedServiceController.cs
+++ b/src/Umbraco.AuthorizedServices/Controllers/AuthorizedServiceController.cs
@@ -52,23 +52,28 @@ public class AuthorizedServiceController : BackOfficeNotificationsController
     {
         ServiceDetail serviceDetail = _serviceDetailOptions.Get(alias);
 
-        bool tokenExists = _tokenStorage.GetToken(alias) != null;
+        bool isAuthorized = CheckAuthorizationStatus(serviceDetail);
 
         string? authorizationUrl = null;
-        if (!tokenExists)
+        if (serviceDetail.AuthenticationMethod == AuthenticationMethod.OAuth2)
         {
-            AuthorizationPayload authorizationPayload = _authorizedServiceAuthorizationPayloadBuilder.BuildPayload();
+            bool tokenExists = _tokenStorage.GetToken(alias) != null;
 
-            _authorizedServiceAuthorizationPayloadCache.Add(alias, authorizationPayload);
+            if (!tokenExists)
+            {
+                AuthorizationPayload authorizationPayload = _authorizedServiceAuthorizationPayloadBuilder.BuildPayload();
 
-            authorizationUrl = _authorizationUrlBuilder
-                .BuildUrl(serviceDetail, HttpContext, authorizationPayload.State, authorizationPayload.CodeChallenge);
+                _authorizedServiceAuthorizationPayloadCache.Add(alias, authorizationPayload);
+
+                authorizationUrl = _authorizationUrlBuilder
+                    .BuildUrl(serviceDetail, HttpContext, authorizationPayload.State, authorizationPayload.CodeChallenge);
+            }
         }
 
         return new AuthorizedServiceDisplay
         {
             DisplayName = serviceDetail.DisplayName,
-            IsAuthorized = tokenExists,
+            IsAuthorized = isAuthorized,
             AuthorizationUrl = authorizationUrl,
             SampleRequest = serviceDetail.SampleRequest,
             Settings = new Dictionary<string, string>
@@ -76,11 +81,14 @@ public class AuthorizedServiceController : BackOfficeNotificationsController
                 { nameof(ServiceDetail.Alias), serviceDetail.Alias },
                 { nameof(ServiceDetail.DisplayName), serviceDetail.DisplayName },
                 { nameof(ServiceDetail.ApiHost), serviceDetail.ApiHost },
+                { nameof(ServiceDetail.AuthenticationMethod), serviceDetail.AuthenticationMethod.ToString() },
                 { nameof(ServiceDetail.IdentityHost), serviceDetail.IdentityHost },
                 { nameof(ServiceDetail.TokenHost), serviceDetail.TokenHost },
                 { nameof(ServiceDetail.RequestIdentityPath), serviceDetail.RequestIdentityPath },
                 { nameof(ServiceDetail.RequestTokenPath), serviceDetail.RequestTokenPath },
-                { nameof(ServiceDetail.RequestTokenFormat), serviceDetail.RequestTokenFormat.ToString() },
+                { nameof(ServiceDetail.RequestTokenFormat), serviceDetail.RequestTokenFormat is not null ? serviceDetail.RequestTokenFormat.Value.ToString() : string.Empty },
+                { nameof(ServiceDetail.ApiKey), serviceDetail.ApiKey },
+                { nameof(ServiceDetail.ApiKeyProvision), serviceDetail.ApiKeyProvision is not null ? serviceDetail.ApiKeyProvision.ToString() : string.Empty },
                 { nameof(ServiceDetail.ClientId), serviceDetail.ClientId },
                 { nameof(ServiceDetail.ClientSecret), new string('*', serviceDetail.ClientSecret.Length) },
                 { nameof(ServiceDetail.Scopes), serviceDetail.Scopes },
@@ -117,4 +125,12 @@ public class AuthorizedServiceController : BackOfficeNotificationsController
         _tokenStorage.DeleteToken(model.Alias);
         return Ok();
     }
+
+    private bool CheckAuthorizationStatus(ServiceDetail serviceDetail) => serviceDetail.AuthenticationMethod switch
+    {
+        AuthenticationMethod.OAuth1 => false,
+        AuthenticationMethod.OAuth2 => _tokenStorage.GetToken(serviceDetail.Alias) != null,
+        AuthenticationMethod.ApiKey => !string.IsNullOrEmpty(serviceDetail.ApiKey),
+        _ => false
+    };
 }

--- a/src/Umbraco.AuthorizedServices/Services/IAuthorizedRequestBuilder.cs
+++ b/src/Umbraco.AuthorizedServices/Services/IAuthorizedRequestBuilder.cs
@@ -18,7 +18,7 @@ public interface IAuthorizedRequestBuilder
     /// <param name="token">The authorization token.</param>
     /// <param name="requestContent">The request data.</param>
     /// <returns>The request instance.</returns>
-    HttpRequestMessage CreateRequestMessage<TRequest>(
+    HttpRequestMessage CreateRequestMessageWithToken<TRequest>(
         ServiceDetail serviceDetail,
         string path,
         HttpMethod httpMethod,
@@ -35,7 +35,7 @@ public interface IAuthorizedRequestBuilder
     /// <param name="httpMethod">The HTTP method.</param>
     /// <param name="requestContent">The request data.</param>
     /// <returns>The request instance.</returns>
-    HttpRequestMessage CreateRequestMessage<TRequest>(
+    HttpRequestMessage CreateRequestMessageWithApiKey<TRequest>(
         ServiceDetail serviceDetail,
         string path,
         HttpMethod httpMethod,

--- a/src/Umbraco.AuthorizedServices/Services/IAuthorizedRequestBuilder.cs
+++ b/src/Umbraco.AuthorizedServices/Services/IAuthorizedRequestBuilder.cs
@@ -25,4 +25,20 @@ public interface IAuthorizedRequestBuilder
         Token token,
         TRequest? requestContent)
         where TRequest : class;
+
+    /// <summary>
+    /// Creates an request to an authorized service using API key.
+    /// </summary>
+    /// <typeparam name="TRequest">The typed request data.</typeparam>
+    /// <param name="serviceDetail">The service detail.</param>
+    /// <param name="path">The request path.</param>
+    /// <param name="httpMethod">The HTTP method.</param>
+    /// <param name="requestContent">The request data.</param>
+    /// <returns>The request instance.</returns>
+    HttpRequestMessage CreateRequestMessage<TRequest>(
+        ServiceDetail serviceDetail,
+        string path,
+        HttpMethod httpMethod,
+        TRequest? requestContent)
+        where TRequest : class;
 }

--- a/src/Umbraco.AuthorizedServices/Services/IAuthorizedServiceCaller.cs
+++ b/src/Umbraco.AuthorizedServices/Services/IAuthorizedServiceCaller.cs
@@ -63,5 +63,5 @@ public interface IAuthorizedServiceCaller
     /// </summary>
     /// <param name="serviceAlias"></param>
     /// <returns></returns>
-    Task<string> GetApiKeyAsync(string serviceAlias);
+    string? GetApiKey(string serviceAlias);
 }

--- a/src/Umbraco.AuthorizedServices/Services/IAuthorizedServiceCaller.cs
+++ b/src/Umbraco.AuthorizedServices/Services/IAuthorizedServiceCaller.cs
@@ -59,7 +59,7 @@ public interface IAuthorizedServiceCaller
         where TRequest : class;
 
     /// <summary>
-    /// Sends a request to retrieve the API key for a service.
+    /// Retrieve's the configured API key for a service.
     /// </summary>
     /// <param name="serviceAlias"></param>
     /// <returns></returns>

--- a/src/Umbraco.AuthorizedServices/Services/IAuthorizedServiceCaller.cs
+++ b/src/Umbraco.AuthorizedServices/Services/IAuthorizedServiceCaller.cs
@@ -57,4 +57,11 @@ public interface IAuthorizedServiceCaller
 
     Task<string> SendRequestRawAsync<TRequest>(string serviceAlias, string path, HttpMethod httpMethod, TRequest? requestContent = null)
         where TRequest : class;
+
+    /// <summary>
+    /// Sends a request to retrieve the API key for a service.
+    /// </summary>
+    /// <param name="serviceAlias"></param>
+    /// <returns></returns>
+    Task<string> GetApiKeyAsync(string serviceAlias);
 }

--- a/src/Umbraco.AuthorizedServices/Services/Implement/AuthorizedRequestBuilder.cs
+++ b/src/Umbraco.AuthorizedServices/Services/Implement/AuthorizedRequestBuilder.cs
@@ -1,5 +1,7 @@
+using System.Collections.Specialized;
 using System.Net.Http.Headers;
 using System.Text;
+using System.Web;
 using Umbraco.AuthorizedServices.Configuration;
 using Umbraco.AuthorizedServices.Models;
 using Umbraco.Cms.Core.Serialization;
@@ -30,6 +32,37 @@ internal sealed class AuthorizedRequestBuilder : IAuthorizedRequestBuilder
         requestMessage.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token.AccessToken);
         requestMessage.Headers.UserAgent.Add(new ProductInfoHeaderValue("UmbracoServiceIntegration", "1.0.0"));
         requestMessage.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+        return requestMessage;
+    }
+
+    public HttpRequestMessage CreateRequestMessage<TRequest>(
+       ServiceDetail serviceDetail,
+       string path,
+       HttpMethod httpMethod,
+       TRequest? requestContent)
+       where TRequest : class
+    {
+        var requestUri = new Uri(serviceDetail.ApiHost + path);
+        if (serviceDetail.ApiKeyProvision is not null && serviceDetail.ApiKeyProvision.Method == ApiKeyProvisionMethod.QueryString)
+        {
+            NameValueCollection queryStringParams = HttpUtility.ParseQueryString(requestUri.Query);
+
+            requestUri = new Uri($"{requestUri}{(queryStringParams.Count > 0 ? "&" : "?")}{serviceDetail.ApiKeyProvision.Key}={serviceDetail.ApiKey}");
+        }
+
+        var requestMessage = new HttpRequestMessage
+        {
+            Method = httpMethod,
+            RequestUri= requestUri,
+            Content = GetRequestContent(serviceDetail, requestContent)
+        };
+
+        if (serviceDetail.ApiKeyProvision is not null && serviceDetail.ApiKeyProvision.Method == ApiKeyProvisionMethod.HttpHeader)
+        {
+            requestMessage.Headers.Add(serviceDetail.ApiKeyProvision.Key, serviceDetail.ApiKey);
+        }
+
+        requestMessage.Headers.UserAgent.Add(new ProductInfoHeaderValue("UmbracoServiceIntegration", "1.0.0"));
         return requestMessage;
     }
 

--- a/src/Umbraco.AuthorizedServices/Services/Implement/AuthorizedRequestBuilder.cs
+++ b/src/Umbraco.AuthorizedServices/Services/Implement/AuthorizedRequestBuilder.cs
@@ -25,7 +25,10 @@ internal sealed class AuthorizedRequestBuilder : IAuthorizedRequestBuilder
         TRequest? requestContent)
         where TRequest : class
     {
-        var requestMessage = CreateRequestMessage(httpMethod, new Uri(serviceDetail.ApiHost + path));
+        HttpRequestMessage requestMessage = CreateRequestMessage(
+            httpMethod,
+            new Uri(serviceDetail.ApiHost + path),
+            GetRequestContent(serviceDetail, requestContent));
         requestMessage.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token.AccessToken);
         AddCommonHeaders(requestMessage);
         return requestMessage;
@@ -55,7 +58,10 @@ internal sealed class AuthorizedRequestBuilder : IAuthorizedRequestBuilder
             requestUri = new Uri($"{requestUri}{(queryStringParams.Count > 0 ? "&" : "?")}{serviceDetail.ApiKeyProvision.Key}={serviceDetail.ApiKey}");
         }
 
-        var requestMessage = CreateRequestMessage(httpMethod, requestUri);
+        HttpRequestMessage requestMessage = CreateRequestMessage(
+            httpMethod,
+            requestUri,
+            GetRequestContent(serviceDetail, requestContent));
 
         if (serviceDetail.ApiKeyProvision.Method == ApiKeyProvisionMethod.HttpHeader)
         {
@@ -66,12 +72,12 @@ internal sealed class AuthorizedRequestBuilder : IAuthorizedRequestBuilder
         return requestMessage;
     }
 
-    private HttpRequestMessage CreateRequestMessage(HttpMethod httpMethod, Uri requestUri) =>
+    private HttpRequestMessage CreateRequestMessage(HttpMethod httpMethod, Uri requestUri, HttpContent? content) =>
         new HttpRequestMessage
         {
             Method = httpMethod,
             RequestUri = requestUri,
-            Content = GetRequestContent(serviceDetail, requestContent)
+            Content = content
         };
 
     private StringContent? GetRequestContent<TRequest>(ServiceDetail serviceDetail, TRequest? requestContent)

--- a/src/Umbraco.AuthorizedServices/Services/Implement/AuthorizedRequestBuilder.cs
+++ b/src/Umbraco.AuthorizedServices/Services/Implement/AuthorizedRequestBuilder.cs
@@ -14,7 +14,7 @@ internal sealed class AuthorizedRequestBuilder : IAuthorizedRequestBuilder
 
     public AuthorizedRequestBuilder(JsonSerializerFactory jsonSerializerFactory) => _jsonSerializerFactory = jsonSerializerFactory;
 
-    public HttpRequestMessage CreateRequestMessage<TRequest>(
+    public HttpRequestMessage CreateRequestMessageWithToken<TRequest>(
         ServiceDetail serviceDetail,
         string path,
         HttpMethod httpMethod,
@@ -35,7 +35,7 @@ internal sealed class AuthorizedRequestBuilder : IAuthorizedRequestBuilder
         return requestMessage;
     }
 
-    public HttpRequestMessage CreateRequestMessage<TRequest>(
+    public HttpRequestMessage CreateRequestMessageWithApiKey<TRequest>(
        ServiceDetail serviceDetail,
        string path,
        HttpMethod httpMethod,

--- a/src/Umbraco.AuthorizedServices/Services/Implement/AuthorizedRequestBuilder.cs
+++ b/src/Umbraco.AuthorizedServices/Services/Implement/AuthorizedRequestBuilder.cs
@@ -42,8 +42,18 @@ internal sealed class AuthorizedRequestBuilder : IAuthorizedRequestBuilder
        TRequest? requestContent)
        where TRequest : class
     {
+        if (string.IsNullOrWhiteSpace(serviceDetail.ApiKey))
+        {
+            throw new InvalidOperationException("Cannot create an HTTP request message for an API key request as no API key is available in configuration.");
+        }
+
+        if (serviceDetail.ApiKeyProvision is null)
+        {
+            throw new InvalidOperationException("Cannot create an HTTP request message for an API key request as no API key provision detail has been provided in configuration.");
+        }
+
         var requestUri = new Uri(serviceDetail.ApiHost + path);
-        if (serviceDetail.ApiKeyProvision is not null && serviceDetail.ApiKeyProvision.Method == ApiKeyProvisionMethod.QueryString)
+        if (serviceDetail.ApiKeyProvision.Method == ApiKeyProvisionMethod.QueryString)
         {
             NameValueCollection queryStringParams = HttpUtility.ParseQueryString(requestUri.Query);
 
@@ -57,7 +67,7 @@ internal sealed class AuthorizedRequestBuilder : IAuthorizedRequestBuilder
             Content = GetRequestContent(serviceDetail, requestContent)
         };
 
-        if (serviceDetail.ApiKeyProvision is not null && serviceDetail.ApiKeyProvision.Method == ApiKeyProvisionMethod.HttpHeader)
+        if (serviceDetail.ApiKeyProvision.Method == ApiKeyProvisionMethod.HttpHeader)
         {
             requestMessage.Headers.Add(serviceDetail.ApiKeyProvision.Key, serviceDetail.ApiKey);
         }

--- a/src/Umbraco.AuthorizedServices/Services/Implement/AuthorizedServiceCaller.cs
+++ b/src/Umbraco.AuthorizedServices/Services/Implement/AuthorizedServiceCaller.cs
@@ -108,6 +108,12 @@ internal sealed class AuthorizedServiceCaller : AuthorizedServiceBase, IAuthoriz
             await response.Content.ReadAsStringAsync());
     }
 
+    public async Task<string> GetApiKeyAsync(string serviceAlias) => await Task.Run(() =>
+                                                                          {
+                                                                              ServiceDetail serviceDetail = GetServiceDetail(serviceAlias);
+                                                                              return serviceDetail.ApiKey;
+                                                                          });
+
     private async Task<Token> EnsureAccessToken(string serviceAlias, Token token)
     {
         if (token.HasOrIsAboutToExpire)

--- a/src/Umbraco.AuthorizedServices/Services/Implement/AuthorizedServiceCaller.cs
+++ b/src/Umbraco.AuthorizedServices/Services/Implement/AuthorizedServiceCaller.cs
@@ -80,7 +80,7 @@ internal sealed class AuthorizedServiceCaller : AuthorizedServiceBase, IAuthoriz
         HttpRequestMessage requestMessage;
         if (serviceDetail.AuthenticationMethod == AuthenticationMethod.ApiKey)
         {
-            requestMessage = _authorizedRequestBuilder.CreateRequestMessage(serviceDetail, path, httpMethod, requestContent);
+            requestMessage = _authorizedRequestBuilder.CreateRequestMessageWithApiKey(serviceDetail, path, httpMethod, requestContent);
         }
         else
         {
@@ -88,7 +88,7 @@ internal sealed class AuthorizedServiceCaller : AuthorizedServiceBase, IAuthoriz
 
             token = await EnsureAccessToken(serviceAlias, token);
 
-            requestMessage = _authorizedRequestBuilder.CreateRequestMessage(serviceDetail, path, httpMethod, token, requestContent);
+            requestMessage = _authorizedRequestBuilder.CreateRequestMessageWithToken(serviceDetail, path, httpMethod, token, requestContent);
         }
 
         HttpResponseMessage response = await httpClient.SendAsync(requestMessage);
@@ -108,11 +108,11 @@ internal sealed class AuthorizedServiceCaller : AuthorizedServiceBase, IAuthoriz
             await response.Content.ReadAsStringAsync());
     }
 
-    public async Task<string> GetApiKeyAsync(string serviceAlias) => await Task.Run(() =>
-                                                                          {
-                                                                              ServiceDetail serviceDetail = GetServiceDetail(serviceAlias);
-                                                                              return serviceDetail.ApiKey;
-                                                                          });
+    public string? GetApiKey(string serviceAlias)
+    {
+        ServiceDetail serviceDetail = GetServiceDetail(serviceAlias);
+        return serviceDetail?.ApiKey;
+    }
 
     private async Task<Token> EnsureAccessToken(string serviceAlias, Token token)
     {

--- a/src/Umbraco.AuthorizedServices/appsettings-schema.Umbraco.AuthorizedServices.json
+++ b/src/Umbraco.AuthorizedServices/appsettings-schema.Umbraco.AuthorizedServices.json
@@ -46,6 +46,10 @@
           "type": "string",
           "description": "Gets or sets the display name for the service."
         },
+        "AuthenticationMethod": {
+          "type": "string",
+          "description": "Gets or sets the authentication method for the service."
+        },
         "ApiHost": {
           "type": "string",
           "description": "Gets or sets the host name for the service's API."
@@ -82,6 +86,13 @@
           "type": "boolean",
           "description": "Gets or sets a value indicating whether the basic token should be included in the token request."
         },
+        "ApiKey": {
+          "type": "string",
+          "description": "Gets or sets the API Key for the service."
+        },
+        "ApiKeyProvision": {
+          "$ref": "#/definitions/ApiKeyProvision"
+        },
         "ClientId": {
           "type": "string",
           "description": "Gets or sets the client Id for the app registered with the service."
@@ -114,6 +125,12 @@
           "type": "string",
           "description": "Gets or sets the path to a GET request used as a sample for verifying the service in the backoffice."
         }
+      }
+    },
+    "ApiKeyProvision": {
+      "type": "object",
+      "description": "Strongly typed configuration for provisioning options for an API key based authentication.",
+      "properties": {
       }
     }
   }

--- a/tests/Umbraco.AuthorizedServices.Tests/Services/AuthorizationRequestSenderTests.cs
+++ b/tests/Umbraco.AuthorizedServices.Tests/Services/AuthorizationRequestSenderTests.cs
@@ -15,7 +15,8 @@ internal class AuthorizationRequestSenderTests
         var serviceDetail = new ServiceDetail
         {
             TokenHost = "https://service.url",
-            RequestTokenPath = "/login/oauth/access_token"
+            RequestTokenPath = "/login/oauth/access_token",
+            RequestTokenFormat = TokenRequestContentFormat.Querystring
         };
         var httpMessageHandlerMock = new Mock<HttpMessageHandler>();
         httpMessageHandlerMock.Protected()

--- a/tests/Umbraco.AuthorizedServices.Tests/Services/AuthorizedRequestBuilderTests.cs
+++ b/tests/Umbraco.AuthorizedServices.Tests/Services/AuthorizedRequestBuilderTests.cs
@@ -27,7 +27,7 @@ internal class AuthorizedRequestBuilderTests : AuthorizedServiceTestsBase
         var sut = new AuthorizedRequestBuilder(factory);
 
         // Act
-        HttpRequestMessage result = sut.CreateRequestMessage(serviceDetail, Path, HttpMethod.Post, token, data);
+        HttpRequestMessage result = sut.CreateRequestMessageWithToken(serviceDetail, Path, HttpMethod.Post, token, data);
 
         // Assert
         var expectedUri = new Uri("https://service.url/api/test");

--- a/tests/Umbraco.AuthorizedServices.Tests/Services/AuthorizedServiceTestsBase.cs
+++ b/tests/Umbraco.AuthorizedServices.Tests/Services/AuthorizedServiceTestsBase.cs
@@ -10,14 +10,15 @@ internal abstract class AuthorizedServiceTestsBase
 
     protected Mock<ITokenStorage> TokenStorageMock { get; set; } = null!;
 
-    protected static Mock<IOptionsMonitor<ServiceDetail>> CreateOptionsMonitorServiceDetail()
+    protected static Mock<IOptionsMonitor<ServiceDetail>> CreateOptionsMonitorServiceDetail(bool includeApiKey = false)
     {
         var optionsMonitorServiceDetailMock = new Mock<IOptionsMonitor<ServiceDetail>>();
         optionsMonitorServiceDetailMock.Setup(o => o.Get(ServiceAlias)).Returns(new ServiceDetail()
         {
             Alias = ServiceAlias,
             ApiHost = "https://service.url",
-            JsonSerializer = JsonSerializerOption.JsonNet
+            JsonSerializer = JsonSerializerOption.JsonNet,
+            ApiKey = includeApiKey ? "test-api-key" : string.Empty
         });
 
         return optionsMonitorServiceDetailMock;


### PR DESCRIPTION
With this PR, I have included support for making authorized requests using API keys.

Updated included:
- Service detail changes:
    - Authentication methods: available options are `OAuth1`, `OAuth2` and `ApiKey` - default value is `OAuth2`
    - Additional properties for storing the API key and setting for passing it with each request:
        - ApiKey
        - Provisioning settings: Method (query string or HTTP header) and Key (query string name or header name)
- Sample endpoint for retrieving YouTube video details.
- YouTube service settings.
- Authorization status managed depending on the authentication method, based on presence of API key in the settings, or token in the database storage.
- If authorized, the `Revoke` button will be visible only for OAuth methods.
- Additional `CreateRequestMessage` method added, with a new signature where the token is no longer used.
- `RequestMessage` object created based on authentication method, taking into consideration that for API key the URL could already contain query string parameters, so adding the API key would need to be appended accordingly.
- Expose method in `IAuthorizedServiceCaller` for retrieving API key: `GetApiKeyAsync`. I have implemented the method to run async, as it did not invoke any asynchronous methods in its body.
