### PR TITLE
Add support for saving tokens manually

### DIFF
--- a/examples/Umbraco.AuthorizedServices.TestSite/Controllers/TestAuthorizedServicesController.cs
+++ b/examples/Umbraco.AuthorizedServices.TestSite/Controllers/TestAuthorizedServicesController.cs
@@ -100,5 +100,16 @@ public class TestAuthorizedServicesController : UmbracoApiController
 
         return Content(string.Join(", ", response.Select(x => x.ToString())));
     }
+
+    public async Task<IActionResult> GetAccessToken(string serviceAlias)
+    {
+        var response = await _authorizedServiceCaller.GetTokenAsync(serviceAlias);
+        if (response == null)
+        {
+            return Problem("Could not retrieve access token.");
+        }
+
+        return Content(response);
+    }
 }
 

--- a/examples/Umbraco.AuthorizedServices.TestSite/Controllers/TestAuthorizedServicesController.cs
+++ b/examples/Umbraco.AuthorizedServices.TestSite/Controllers/TestAuthorizedServicesController.cs
@@ -101,9 +101,9 @@ public class TestAuthorizedServicesController : UmbracoApiController
         return Content(string.Join(", ", response.Select(x => x.ToString())));
     }
 
-    public async Task<IActionResult> GetAccessToken(string serviceAlias)
+    public IActionResult GetAccessToken(string serviceAlias)
     {
-        var response = await _authorizedServiceCaller.GetTokenAsync(serviceAlias);
+        var response = _authorizedServiceCaller.GetToken(serviceAlias);
         if (response == null)
         {
             return Problem("Could not retrieve access token.");

--- a/src/Umbraco.AuthorizedServices/ClientApp/src/backoffice/AuthorizedServices/edit.controller.ts
+++ b/src/Umbraco.AuthorizedServices/ClientApp/src/backoffice/AuthorizedServices/edit.controller.ts
@@ -49,6 +49,7 @@ function AuthorizedServiceEditController(this: any, $routeParams, $location, aut
         .then(function () {
           notificationsService.success("Authorized Services", "The '" + vm.displayName + "' service access token has been saved.");
           inAccessToken.value = "";
+          loadServiceDetails(serviceAlias);
         });
     }
   }

--- a/src/Umbraco.AuthorizedServices/ClientApp/src/backoffice/AuthorizedServices/edit.controller.ts
+++ b/src/Umbraco.AuthorizedServices/ClientApp/src/backoffice/AuthorizedServices/edit.controller.ts
@@ -10,6 +10,7 @@ function AuthorizedServiceEditController(this: any, $routeParams, $location, aut
         vm.displayName = serviceData.displayName;
         vm.headerName = "Authorized Services: " + vm.displayName;
         vm.isAuthorized = serviceData.isAuthorized;
+        vm.canManuallyProvideToken = serviceData.canManuallyProvideToken;
         vm.authorizationUrl = serviceData.authorizationUrl;
         vm.sampleRequest = serviceData.sampleRequest;
         vm.sampleRequestResponse = null;
@@ -39,6 +40,18 @@ function AuthorizedServiceEditController(this: any, $routeParams, $location, aut
         notificationsService.error("Authorized Services", "The sample request did not complete: " + e.data.ExceptionMessage);
       });
   };
+
+  vm.saveAccessToken = function () {
+    let inAccessToken = <HTMLInputElement>document.getElementById("inAccessToken");
+
+    if (inAccessToken) {
+      authorizedServiceResource.saveToken(serviceAlias, inAccessToken.value)
+        .then(function () {
+          notificationsService.success("Authorized Services", "The '" + vm.displayName + "' service access token has been saved.");
+          inAccessToken.value = "";
+        });
+    }
+  }
 
   loadServiceDetails(serviceAlias);
 

--- a/src/Umbraco.AuthorizedServices/ClientApp/src/backoffice/AuthorizedServices/edit.html
+++ b/src/Umbraco.AuthorizedServices/ClientApp/src/backoffice/AuthorizedServices/edit.html
@@ -44,7 +44,8 @@
             </uui-card-content-node>
             <uui-card-content-node ng-if="vm.canManuallyProvideToken" name="Access Token" class="mt3">
               <uui-icon slot="icon" name="settings"></uui-icon>
-              <p class="auth-srv">Manually enter service access token</p>
+              <p class="auth-srv">Enter service access token</p>
+              <small>This service is configured indicating that a token can be generated via the service's developer portal. Once you have obtained one you can copy and paste it here to authorize the service.</small>
               <div>
                 <uui-input id="inAccessToken" type="text" name="inAccessToken" style="width: 40%;font-size:14px;"></uui-input>
                 <umb-button action="vm.saveAccessToken()"

--- a/src/Umbraco.AuthorizedServices/ClientApp/src/backoffice/AuthorizedServices/edit.html
+++ b/src/Umbraco.AuthorizedServices/ClientApp/src/backoffice/AuthorizedServices/edit.html
@@ -42,6 +42,17 @@
                             label="Authorize Service" />
               </div>
             </uui-card-content-node>
+            <uui-card-content-node ng-if="vm.canManuallyProvideToken" name="Access Token" class="mt3">
+              <uui-icon slot="icon" name="settings"></uui-icon>
+              <p class="auth-srv">Manually enter service access token</p>
+              <div>
+                <uui-input id="inAccessToken" type="text" name="inAccessToken" style="width: 40%;font-size:14px;"></uui-input>
+                <umb-button action="vm.saveAccessToken()"
+                            type="button"
+                            button-style="primary"
+                            label="Save"></umb-button>
+              </div>
+            </uui-card-content-node>
           </uui-icon-registry-essential>
         </umb-box-content>
       </umb-box>

--- a/src/Umbraco.AuthorizedServices/ClientApp/src/backoffice/AuthorizedServices/edit.html
+++ b/src/Umbraco.AuthorizedServices/ClientApp/src/backoffice/AuthorizedServices/edit.html
@@ -36,6 +36,7 @@
                 </div>
               </div>
               <div ng-show="!vm.isAuthorized">
+                <p>To authorize the service click to sign-in to the provider's portal, confirm the permission request and return to Umbraco.</p>
                 <umb-button action="vm.authorizeAccess()"
                             type="button"
                             button-style="success"
@@ -50,9 +51,9 @@
         <umb-box-content>
           <uui-icon-registry-essential>
             <uui-card-content-node name="Access Token">
-              <uui-icon slot="icon" name="settings"></uui-icon>
+              <uui-icon slot="icon" name="add"></uui-icon>
               <p class="auth-srv">Enter service access token</p>
-              <small>This service is configured indicating that a token can be generated via the service's developer portal. Once you have obtained one you can copy and paste it here to authorize the service.</small>
+              <p>This service is configured indicating that a token can be generated via the service's developer portal. Once you have obtained one you can copy and paste it here to authorize the service.</p>
               <div>
                 <uui-input id="inAccessToken" type="text" name="inAccessToken" style="width: 40%;font-size:14px;"></uui-input>
                 <umb-button action="vm.saveAccessToken()"
@@ -69,6 +70,7 @@
         <umb-box-content>
           <uui-icon-registry-essential>
             <uui-card-content-node name="{{ vm.displayName }}">
+              <uui-icon slot="icon" name="settings"></uui-icon>
               <table class="umb-authorizedservices-settings-table">
                 <thead>
                   <tr>

--- a/src/Umbraco.AuthorizedServices/ClientApp/src/backoffice/AuthorizedServices/edit.html
+++ b/src/Umbraco.AuthorizedServices/ClientApp/src/backoffice/AuthorizedServices/edit.html
@@ -42,7 +42,14 @@
                             label="Authorize Service" />
               </div>
             </uui-card-content-node>
-            <uui-card-content-node ng-if="vm.canManuallyProvideToken" name="Access Token" class="mt3">
+          </uui-icon-registry-essential>
+        </umb-box-content>
+      </umb-box>
+      <umb-box ng-if="vm.canManuallyProvideToken">
+        <umb-box-header title="Provide Token"></umb-box-header>
+        <umb-box-content>
+          <uui-icon-registry-essential>
+            <uui-card-content-node name="Access Token">
               <uui-icon slot="icon" name="settings"></uui-icon>
               <p class="auth-srv">Enter service access token</p>
               <small>This service is configured indicating that a token can be generated via the service's developer portal. Once you have obtained one you can copy and paste it here to authorize the service.</small>

--- a/src/Umbraco.AuthorizedServices/ClientApp/src/resources/authorizedservice.resource.ts
+++ b/src/Umbraco.AuthorizedServices/ClientApp/src/resources/authorizedservice.resource.ts
@@ -11,9 +11,11 @@ function authorizedServiceResource($q, $http) {
     sendSampleRequest: function (alias: string, path: string) {
       return $http.get(apiRoot + "SendSampleRequest?alias=" + alias + "&path=" + path);
     },
-
     revokeAccess: function (alias: string) {
       return $http.post(apiRoot + "RevokeAccess", { alias: alias });
+    },
+    saveToken: function (alias: string, token: string) {
+      return $http.post(apiRoot + "SaveToken", { alias: alias, token: token });
     }
   };
 }

--- a/src/Umbraco.AuthorizedServices/Configuration/AuthorizedServiceSettings.cs
+++ b/src/Umbraco.AuthorizedServices/Configuration/AuthorizedServiceSettings.cs
@@ -82,7 +82,7 @@ public class ServiceDetail : ServiceSummary
     public string TokenHost { get; set; } = string.Empty;
 
     /// <summary>
-    /// Get or sets a value indicating whether editor can manually add token.
+    /// Get or sets a value indicating whether an adminsitrator editor can manually provide tokens via the backoffice.
     /// </summary>
     public bool CanManuallyProvideToken { get; set; }
 

--- a/src/Umbraco.AuthorizedServices/Configuration/AuthorizedServiceSettings.cs
+++ b/src/Umbraco.AuthorizedServices/Configuration/AuthorizedServiceSettings.cs
@@ -82,6 +82,11 @@ public class ServiceDetail : ServiceSummary
     public string TokenHost { get; set; } = string.Empty;
 
     /// <summary>
+    /// Get or sets a value indicating whether editor can manually add token.
+    /// </summary>
+    public bool CanManuallyProvideToken { get; set; }
+
+    /// <summary>
     /// Gets or sets the path for requests for authentication with the service.
     /// </summary>
     public string RequestIdentityPath { get; set; } = string.Empty;

--- a/src/Umbraco.AuthorizedServices/Controllers/AuthorizedServiceController.cs
+++ b/src/Umbraco.AuthorizedServices/Controllers/AuthorizedServiceController.cs
@@ -69,6 +69,7 @@ public class AuthorizedServiceController : BackOfficeNotificationsController
         {
             DisplayName = serviceDetail.DisplayName,
             IsAuthorized = tokenExists,
+            CanManuallyProvideToken = serviceDetail.CanManuallyProvideToken,
             AuthorizationUrl = authorizationUrl,
             SampleRequest = serviceDetail.SampleRequest,
             Settings = new Dictionary<string, string>
@@ -115,6 +116,18 @@ public class AuthorizedServiceController : BackOfficeNotificationsController
     public IActionResult RevokeAccess(RevokeAccess model)
     {
         _tokenStorage.DeleteToken(model.Alias);
+        return Ok();
+    }
+
+    /// <summary>
+    /// Adds a new access token for an authorized service.
+    /// </summary>
+    /// <param name="model">Request model identifying the service.</param>
+    /// <returns></returns>
+    [HttpPost]
+    public IActionResult SaveToken(AddToken model)
+    {
+        _tokenStorage.SaveToken(model.Alias, new Token(model.Token));
         return Ok();
     }
 }

--- a/src/Umbraco.AuthorizedServices/Models/AuthorizedServiceDisplay.cs
+++ b/src/Umbraco.AuthorizedServices/Models/AuthorizedServiceDisplay.cs
@@ -21,7 +21,7 @@ public class AuthorizedServiceDisplay
     public bool IsAuthorized { get; set; }
 
     /// <summary>
-    /// Get or sets a value indicating whether editor can manually add token.
+    /// Get or sets a value indicating whether an adminsitrator editor can manually provide tokens via the backoffice.
     /// </summary>
     [DataMember(Name = "canManuallyProvideToken")]
     public bool CanManuallyProvideToken { get; set; }

--- a/src/Umbraco.AuthorizedServices/Models/AuthorizedServiceDisplay.cs
+++ b/src/Umbraco.AuthorizedServices/Models/AuthorizedServiceDisplay.cs
@@ -21,6 +21,12 @@ public class AuthorizedServiceDisplay
     public bool IsAuthorized { get; set; }
 
     /// <summary>
+    /// Get or sets a value indicating whether editor can manually add token.
+    /// </summary>
+    [DataMember(Name = "canManuallyProvideToken")]
+    public bool CanManuallyProvideToken { get; set; }
+
+    /// <summary>
     /// Gets or sets the service's authorization URL.
     /// </summary>
     [DataMember(Name = "authorizationUrl")]

--- a/src/Umbraco.AuthorizedServices/Models/Request/AddToken.cs
+++ b/src/Umbraco.AuthorizedServices/Models/Request/AddToken.cs
@@ -1,0 +1,17 @@
+namespace Umbraco.AuthorizedServices.Models.Request;
+
+/// <summary>
+/// Defines the model used for saving a service token via a backoffice operation.
+/// </summary>
+public class AddToken
+{
+    /// <summary>
+    /// Gets or sets the service alias.
+    /// </summary>
+    public string Alias { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the service token.
+    /// </summary>
+    public string Token { get; set; } = string.Empty;
+}

--- a/src/Umbraco.AuthorizedServices/Models/Token.cs
+++ b/src/Umbraco.AuthorizedServices/Models/Token.cs
@@ -9,20 +9,20 @@ public class Token
     /// Initializes a new instance of the <see cref="Token"/> class.
     /// </summary>
     /// <param name="accessToken">The access token.</param>
-    /// <param name="refreshToken">The refreh token.</param>
-    /// <param name="expiresOn">The date the access token expires.</param>
-    public Token(string accessToken, string? refreshToken, DateTime? expiresOn)
-    {
-        AccessToken = accessToken;
-        RefreshToken = refreshToken;
-        ExpiresOn = expiresOn;
-    }
+    public Token(string accessToken) => AccessToken = accessToken;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="Token"/> class.
     /// </summary>
     /// <param name="accessToken">The access token.</param>
-    public Token(string accessToken) => AccessToken = accessToken;
+    /// <param name="refreshToken">The refreh token.</param>
+    /// <param name="expiresOn">The date the access token expires.</param>
+    public Token(string accessToken, string? refreshToken, DateTime? expiresOn)
+        : this(accessToken)
+    {
+        RefreshToken = refreshToken;
+        ExpiresOn = expiresOn;
+    }
 
     /// <summary>
     /// Gets or sets the access token.

--- a/src/Umbraco.AuthorizedServices/Models/Token.cs
+++ b/src/Umbraco.AuthorizedServices/Models/Token.cs
@@ -19,6 +19,12 @@ public class Token
     }
 
     /// <summary>
+    /// Initializes a new instance of the <see cref="Token"/> class.
+    /// </summary>
+    /// <param name="accessToken">The access token.</param>
+    public Token(string accessToken) => AccessToken = accessToken;
+
+    /// <summary>
     /// Gets or sets the access token.
     /// </summary>
     public string AccessToken { get; }

--- a/src/Umbraco.AuthorizedServices/Services/IAuthorizedServiceCaller.cs
+++ b/src/Umbraco.AuthorizedServices/Services/IAuthorizedServiceCaller.cs
@@ -57,4 +57,11 @@ public interface IAuthorizedServiceCaller
 
     Task<string> SendRequestRawAsync<TRequest>(string serviceAlias, string path, HttpMethod httpMethod, TRequest? requestContent = null)
         where TRequest : class;
+
+    /// <summary>
+    /// Sends a request to an authorized service to receive the unencrypted access token.
+    /// </summary>
+    /// <param name="serviceAlias"></param>
+    /// <returns></returns>
+    Task<string> GetTokenAsync(string serviceAlias);
 }

--- a/src/Umbraco.AuthorizedServices/Services/IAuthorizedServiceCaller.cs
+++ b/src/Umbraco.AuthorizedServices/Services/IAuthorizedServiceCaller.cs
@@ -61,7 +61,7 @@ public interface IAuthorizedServiceCaller
     /// <summary>
     /// Sends a request to an authorized service to receive the unencrypted access token.
     /// </summary>
-    /// <param name="serviceAlias"></param>
-    /// <returns></returns>
-    Task<string> GetTokenAsync(string serviceAlias);
+    /// <param name="serviceAlias">The service alias.</param>
+    /// <returns>The access token if found, otherwise null.</returns>
+    string? GetToken(string serviceAlias);
 }

--- a/src/Umbraco.AuthorizedServices/Services/Implement/AuthorizedServiceCaller.cs
+++ b/src/Umbraco.AuthorizedServices/Services/Implement/AuthorizedServiceCaller.cs
@@ -104,6 +104,16 @@ internal sealed class AuthorizedServiceCaller : AuthorizedServiceBase, IAuthoriz
             await response.Content.ReadAsStringAsync());
     }
 
+    public async Task<string> GetTokenAsync(string serviceAlias)
+    {
+        return await Task.Run(() =>
+        {
+            Token? token = GetAccessToken(serviceAlias)
+                ?? throw new AuthorizedServiceException($"Cannot request service '{serviceAlias}' as access has not yet been authorized.");
+            return token.AccessToken;
+        });
+    }
+
     private async Task<Token> EnsureAccessToken(string serviceAlias, Token token)
     {
         if (token.HasOrIsAboutToExpire)

--- a/src/Umbraco.AuthorizedServices/Services/Implement/AuthorizedServiceCaller.cs
+++ b/src/Umbraco.AuthorizedServices/Services/Implement/AuthorizedServiceCaller.cs
@@ -104,12 +104,11 @@ internal sealed class AuthorizedServiceCaller : AuthorizedServiceBase, IAuthoriz
             await response.Content.ReadAsStringAsync());
     }
 
-    public async Task<string> GetTokenAsync(string serviceAlias) => await Task.Run(() =>
-                                                                         {
-                                                                             Token? token = GetAccessToken(serviceAlias)
-                                                                                 ?? throw new AuthorizedServiceException($"Cannot request service '{serviceAlias}' as access has not yet been authorized.");
-                                                                             return token.AccessToken;
-                                                                         });
+    public string? GetToken(string serviceAlias)
+    {
+        Token? token = GetAccessToken(serviceAlias);
+        return token?.AccessToken;
+    }
 
     private async Task<Token> EnsureAccessToken(string serviceAlias, Token token)
     {

--- a/src/Umbraco.AuthorizedServices/Services/Implement/AuthorizedServiceCaller.cs
+++ b/src/Umbraco.AuthorizedServices/Services/Implement/AuthorizedServiceCaller.cs
@@ -104,15 +104,12 @@ internal sealed class AuthorizedServiceCaller : AuthorizedServiceBase, IAuthoriz
             await response.Content.ReadAsStringAsync());
     }
 
-    public async Task<string> GetTokenAsync(string serviceAlias)
-    {
-        return await Task.Run(() =>
-        {
-            Token? token = GetAccessToken(serviceAlias)
-                ?? throw new AuthorizedServiceException($"Cannot request service '{serviceAlias}' as access has not yet been authorized.");
-            return token.AccessToken;
-        });
-    }
+    public async Task<string> GetTokenAsync(string serviceAlias) => await Task.Run(() =>
+                                                                         {
+                                                                             Token? token = GetAccessToken(serviceAlias)
+                                                                                 ?? throw new AuthorizedServiceException($"Cannot request service '{serviceAlias}' as access has not yet been authorized.");
+                                                                             return token.AccessToken;
+                                                                         });
 
     private async Task<Token> EnsureAccessToken(string serviceAlias, Token token)
     {

--- a/src/Umbraco.AuthorizedServices/appsettings-schema.Umbraco.AuthorizedServices.json
+++ b/src/Umbraco.AuthorizedServices/appsettings-schema.Umbraco.AuthorizedServices.json
@@ -62,6 +62,10 @@
           "type": "string",
           "description": "Gets or sets the path for requests for authentication with the service."
         },
+        "CanManuallyProvideToken": {
+          "type": "boolean",
+          "description": "Get or sets a value indicating whether editor can manually add token."
+        },
         "AuthorizationUrlRequiresRedirectUrl": {
           "type": "boolean",
           "description": "Gets or sets a value indicating whether authorization requests require sending the redirect URL."

--- a/tests/Umbraco.AuthorizedServices.Tests/Services/AuthorizedServiceCallerTests.cs
+++ b/tests/Umbraco.AuthorizedServices.Tests/Services/AuthorizedServiceCallerTests.cs
@@ -147,12 +147,40 @@ internal class AuthorizedServiceCallerTests : AuthorizedServiceTestsBase
             .Verify(x => x.SaveToken(It.Is<string>(y => y == ServiceAlias), It.Is<Token>(y => y.AccessToken == "abc")), Times.Once);
     }
 
+    [Test]
+    public void GetToken_WithStoredToken_ReturnsAccessToken()
+    {
+        // Arrange
+        StoreToken();
+        AuthorizedServiceCaller sut = CreateService();
+
+        // Act
+        var result = sut.GetToken(ServiceAlias);
+
+        // Assert
+        result.Should().NotBeNull();
+        result!.Should().Be("abc");
+    }
+
+    [Test]
+    public void GetToken_WithoutStoredToken_ReturnsNull()
+    {
+        // Arrange
+        AuthorizedServiceCaller sut = CreateService();
+
+        // Act
+        var result = sut.GetToken(ServiceAlias);
+
+        // Assert
+        result.Should().BeNull();
+    }
+
     private void StoreToken(int daysUntilExpiry = 7) =>
         TokenStorageMock
             .Setup(x => x.GetToken(It.Is<string>(y => y == ServiceAlias)))
             .Returns(new Token("abc", "def", DateTime.Now.AddDays(daysUntilExpiry)));
 
-    private AuthorizedServiceCaller CreateService(HttpStatusCode statusCode, string? responseContent = null, HttpStatusCode refreshTokenStatusCode = HttpStatusCode.OK)
+    private AuthorizedServiceCaller CreateService(HttpStatusCode statusCode = HttpStatusCode.OK, string? responseContent = null, HttpStatusCode refreshTokenStatusCode = HttpStatusCode.OK)
     {
         var authorizationRequestSenderMock = new Mock<IAuthorizationRequestSender>();
 


### PR DESCRIPTION
Current PR contains updates for handling access tokens in two manners:
1. Manually add access tokens for a service from the backoffice UI
    - a service that allows the save of access tokens from the interface will have the `CanManuallyProvideToken` property set to true in the settings.
    - this will toggle an input text field to be made visible in the backoffice service details page, where the editor can save a new access token.
![image](https://github.com/umbraco/Umbraco.AuthorizedServices/assets/95346674/0bad1a0f-6483-4b2d-9f03-228e347d7343)
    - a successful result will be displayed to the user.
![image](https://github.com/umbraco/Umbraco.AuthorizedServices/assets/95346674/59aa761b-55ee-4140-8caf-02e8af701391)

2. Extend `IAuthorizedServiceCaller` interface to retrieve the access token for a service using the `GetTokenAsync` method. I have implemented the method to run async, as it did not invoke any asynchronous methods in its body.

Schema has been updated with details of the `CanManuallyProvideToken` property.