### PR TITLE
Use authentication method for toggling visibility of revoke access ac…

### DIFF
--- a/src/Umbraco.AuthorizedServices/ClientApp/src/backoffice/AuthorizedServices/edit.controller.ts
+++ b/src/Umbraco.AuthorizedServices/ClientApp/src/backoffice/AuthorizedServices/edit.controller.ts
@@ -10,6 +10,7 @@ function AuthorizedServiceEditController(this: any, $routeParams, $location, aut
         vm.displayName = serviceData.displayName;
         vm.headerName = "Authorized Services: " + vm.displayName;
         vm.isAuthorized = serviceData.isAuthorized;
+        vm.authenticationMethod = serviceData.authenticationMethod;
         vm.canManuallyProvideToken = serviceData.canManuallyProvideToken;
         vm.authorizationUrl = serviceData.authorizationUrl;
         vm.sampleRequest = serviceData.sampleRequest;

--- a/src/Umbraco.AuthorizedServices/ClientApp/src/backoffice/AuthorizedServices/edit.html
+++ b/src/Umbraco.AuthorizedServices/ClientApp/src/backoffice/AuthorizedServices/edit.html
@@ -24,7 +24,7 @@
                             action="vm.sendSampleRequest()"
                             type="button"
                             label="Verify Sample Request"></umb-button>
-                <umb-button ng-if="vm.authorizationUrl.length > 0"
+                <umb-button ng-if="vm.authenticationMethod !== 'ApiKey'"
                             action="vm.revokeAccess()"
                             type="button"
                             button-style="danger"

--- a/src/Umbraco.AuthorizedServices/Controllers/AuthorizedServiceController.cs
+++ b/src/Umbraco.AuthorizedServices/Controllers/AuthorizedServiceController.cs
@@ -74,6 +74,7 @@ public class AuthorizedServiceController : BackOfficeNotificationsController
             IsAuthorized = isAuthorized,
             CanManuallyProvideToken = serviceDetail.CanManuallyProvideToken,
             AuthorizationUrl = authorizationUrl,
+            AuthenticationMethod = serviceDetail.AuthenticationMethod.ToString(),
             SampleRequest = serviceDetail.SampleRequest,
             Settings = new Dictionary<string, string>
             {

--- a/src/Umbraco.AuthorizedServices/Models/AuthorizedServiceDisplay.cs
+++ b/src/Umbraco.AuthorizedServices/Models/AuthorizedServiceDisplay.cs
@@ -1,4 +1,5 @@
 using System.Runtime.Serialization;
+using Umbraco.AuthorizedServices.Configuration;
 
 namespace Umbraco.AuthorizedServices.Models;
 
@@ -31,6 +32,12 @@ public class AuthorizedServiceDisplay
     /// </summary>
     [DataMember(Name = "authorizationUrl")]
     public string? AuthorizationUrl { get; set; }
+
+    /// <summary>
+    /// Gets or sets the service's authentication method.
+    /// </summary>
+    [DataMember(Name = "authenticationMethod")]
+    public string AuthenticationMethod { get; set; } = Configuration.AuthenticationMethod.OAuth2.ToString();
 
     /// <summary>
     /// Gets or sets a sample GET request for the service, used for verification.


### PR DESCRIPTION
While documenting latest updates on `AuthorizedServices`, I came across a bug in the UI: the `Revoke Access` button was not visibile if `AuthenticationMethod = OAuth2`, because the authorization URL string used for toggling visibility was not properly set.

To address this, I'm passing the authentication method to the client-side and use its value to displaying the button.