### PR TITLE
OAuth2 Client Credentials implementation

### DIFF
--- a/examples/Umbraco.AuthorizedServices.TestSite/appsettings.json
+++ b/examples/Umbraco.AuthorizedServices.TestSite/appsettings.json
@@ -440,7 +440,38 @@
           "ClientId": "",
           "ClientSecret": "",
           "Scopes": "",
-          "SampleRequest": "/v3/videos?id=[video_id]&part=snippet,contentDetails,statistics,status"
+          "SampleRequest": "/v3/videos?id=1&part=snippet,contentDetails,statistics,status"
+        },
+        "salesforce": {
+          "DisplayName": "Salesforce",
+          "AuthenticationMethod": "OAuth2ClientCredentials",
+          "ClientCredentialsProvision": "AuthHeader",
+          "ApiHost": "https://[sf-instance].my.salesforce.com",
+          "IdentityHost": "https://[sf-instance].my.salesforce.com",
+          "TokenHost": "https://[sf-instance].my.salesforce.com",
+          "RequestIdentityPath": "",
+          "RequestTokenPath": "/services/oauth2/token",
+          "RequestTokenFormat": "FormUrlEncoded",
+          "ClientId": "",
+          "ClientSecret": "",
+          "Scopes": "",
+          "SampleRequest": "/services/data/v59.0/sobjects"
+        },
+        "microsoft": {
+          "DisplayName": "Microsoft",
+          "AuthenticationMethod": "OAuth2ClientCredentials",
+          "ClientCredentialsProvision": "RequestBody",
+          "ApiHost": "https://graph.microsoft.com",
+          "IdentityHost": "https://login.microsoftonline.com",
+          "TokenHost": "https://login.microsoftonline.com",
+          "RequestIdentityPath": "",
+          "RequestTokenPath": "/[tenant-id]/oauth2/v2.0/token",
+          "RequestTokenFormat": "FormUrlEncoded",
+          "ClientId": "",
+          "ClientSecret": "",
+          "Scopes": "https://graph.microsoft.com/.default",
+          "IncludeScopesInAuthorizationRequest": true,
+          "SampleRequest": "/me"
         }
       }
     }

--- a/src/Umbraco.AuthorizedServices/ClientApp/src/backoffice/AuthorizedServices/authorizedservice.constants.ts
+++ b/src/Umbraco.AuthorizedServices/ClientApp/src/backoffice/AuthorizedServices/authorizedservice.constants.ts
@@ -1,6 +1,6 @@
 export enum AuthenticationMethod {
   OAuth1 = "OAuth1",
-  OAuth2 = "OAuth2",
+  OAuth2AuthorizationCode = "OAuth2AuthorizationCode",
   OAuth2ClientCredentials = "OAuth2ClientCredentials",
   ApiKey = "ApiKey"
 }

--- a/src/Umbraco.AuthorizedServices/ClientApp/src/backoffice/AuthorizedServices/authorizedservice.constants.ts
+++ b/src/Umbraco.AuthorizedServices/ClientApp/src/backoffice/AuthorizedServices/authorizedservice.constants.ts
@@ -1,0 +1,6 @@
+export enum AuthenticationMethod {
+  OAuth1 = "OAuth1",
+  OAuth2 = "OAuth2",
+  OAuth2ClientCredentials = "OAuth2ClientCredentials",
+  ApiKey = "ApiKey"
+}

--- a/src/Umbraco.AuthorizedServices/ClientApp/src/backoffice/AuthorizedServices/edit.controller.ts
+++ b/src/Umbraco.AuthorizedServices/ClientApp/src/backoffice/AuthorizedServices/edit.controller.ts
@@ -1,3 +1,5 @@
+import { AuthenticationMethod } from "./authorizedservice.constants";
+
 function AuthorizedServiceEditController(this: any, $routeParams, $location, authorizedServiceResource, notificationsService) {
 
   const vm = this;
@@ -20,7 +22,16 @@ function AuthorizedServiceEditController(this: any, $routeParams, $location, aut
   }
 
   vm.authorizeAccess = function () {
-    location.href = vm.authorizationUrl;
+    if (vm.authenticationMethod.toString() === AuthenticationMethod.OAuth2ClientCredentials.toString()) {
+      authorizedServiceResource.generateToken(serviceAlias)
+        .then(function () {
+          notificationsService.success("Authorized Services", "The '" + vm.displayName + "' service has been authorized.");
+          loadServiceDetails(serviceAlias);
+        });
+    }
+    else {
+      location.href = vm.authorizationUrl;
+    }
   };
 
   vm.revokeAccess = function () {

--- a/src/Umbraco.AuthorizedServices/ClientApp/src/backoffice/AuthorizedServices/edit.controller.ts
+++ b/src/Umbraco.AuthorizedServices/ClientApp/src/backoffice/AuthorizedServices/edit.controller.ts
@@ -18,6 +18,7 @@ function AuthorizedServiceEditController(this: any, $routeParams, $location, aut
         vm.sampleRequest = serviceData.sampleRequest;
         vm.sampleRequestResponse = null;
         vm.settings = serviceData.settings;
+        vm.isApiKeyBasedAuthenticationMethod = serviceData.authenticationMethod === AuthenticationMethod.ApiKey;
       });
   }
 

--- a/src/Umbraco.AuthorizedServices/ClientApp/src/backoffice/AuthorizedServices/edit.html
+++ b/src/Umbraco.AuthorizedServices/ClientApp/src/backoffice/AuthorizedServices/edit.html
@@ -24,7 +24,7 @@
                             action="vm.sendSampleRequest()"
                             type="button"
                             label="Verify Sample Request"></umb-button>
-                <umb-button ng-if="vm.authenticationMethod !== 'ApiKey'"
+                <umb-button ng-if="!vm.isApiKeyBasedAuthenticationMethod"
                             action="vm.revokeAccess()"
                             type="button"
                             button-style="danger"

--- a/src/Umbraco.AuthorizedServices/ClientApp/src/resources/authorizedservice.resource.ts
+++ b/src/Umbraco.AuthorizedServices/ClientApp/src/resources/authorizedservice.resource.ts
@@ -16,6 +16,9 @@ function authorizedServiceResource($q, $http) {
     },
     saveToken: function (alias: string, token: string) {
       return $http.post(apiRoot + "SaveToken", { alias: alias, token: token });
+    },
+    generateToken: function (alias: string) {
+      return $http.post(apiRoot + "GenerateToken", { alias: alias });
     }
   };
 }

--- a/src/Umbraco.AuthorizedServices/Configuration/AuthorizedServiceSettings.cs
+++ b/src/Umbraco.AuthorizedServices/Configuration/AuthorizedServiceSettings.cs
@@ -38,7 +38,7 @@ public enum JsonSerializerOption
 public enum AuthenticationMethod
 {
     OAuth1,
-    OAuth2,
+    OAuth2AuthorizationCode,
     OAuth2ClientCredentials,
     ApiKey
 }
@@ -110,12 +110,12 @@ public class ServiceDetail : ServiceSummary
     /// <summary>
     /// Gets or sets the authentication method for the service.
     /// </summary>
-    public AuthenticationMethod AuthenticationMethod { get; set; } = AuthenticationMethod.OAuth2;
+    public AuthenticationMethod AuthenticationMethod { get; set; } = AuthenticationMethod.OAuth2AuthorizationCode;
 
     /// <summary>
     /// Gets or sets the provisioning type for an OAuth2 Client Credentials flow.
     /// </summary>
-    public ClientCredentialsProvision ClientCredentialsProvision { get; set; }
+    public ClientCredentialsProvision ClientCredentialsProvision { get; set; } = ClientCredentialsProvision.RequestBody;
 
     /// <summary>
     /// Gets or sets the host name for the service's API.

--- a/src/Umbraco.AuthorizedServices/Configuration/AuthorizedServiceSettings.cs
+++ b/src/Umbraco.AuthorizedServices/Configuration/AuthorizedServiceSettings.cs
@@ -39,6 +39,7 @@ public enum AuthenticationMethod
 {
     OAuth1,
     OAuth2,
+    OAuth2ClientCredentials,
     ApiKey
 }
 
@@ -49,6 +50,15 @@ public enum ApiKeyProvisionMethod
 {
     HttpHeader,
     QueryString
+}
+
+/// <summary>
+/// Defines the available provisioning methods for an OAuth2 Client Credentials flow.
+/// </summary>
+public enum ClientCredentialsProvision
+{
+    AuthHeader,
+    RequestBody
 }
 
 /// <summary>
@@ -101,6 +111,11 @@ public class ServiceDetail : ServiceSummary
     /// Gets or sets the authentication method for the service.
     /// </summary>
     public AuthenticationMethod AuthenticationMethod { get; set; } = AuthenticationMethod.OAuth2;
+
+    /// <summary>
+    /// Gets or sets the provisioning type for an OAuth2 Client Credentials flow.
+    /// </summary>
+    public ClientCredentialsProvision ClientCredentialsProvision { get; set; }
 
     /// <summary>
     /// Gets or sets the host name for the service's API.
@@ -176,6 +191,11 @@ public class ServiceDetail : ServiceSummary
     /// Gets or sets the scopes required for working with the service.
     /// </summary>
     public string Scopes { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets whether the scopes should be included in the authorization request body.
+    /// </summary>
+    public bool IncludeScopesInAuthorizationRequest { get; set; }
 
     /// <summary>
     /// Gets or sets a value indicating whether the OAuth flow should use Proof of Key Code Exchange (PKCE).

--- a/src/Umbraco.AuthorizedServices/Controllers/AuthorizedServiceController.cs
+++ b/src/Umbraco.AuthorizedServices/Controllers/AuthorizedServiceController.cs
@@ -166,9 +166,11 @@ public class AuthorizedServiceController : BackOfficeNotificationsController
     private bool CheckAuthorizationStatus(ServiceDetail serviceDetail) => serviceDetail.AuthenticationMethod switch
     {
         AuthenticationMethod.OAuth1 => false,
-        AuthenticationMethod.OAuth2AuthorizationCode => _tokenStorage.GetToken(serviceDetail.Alias) != null,
-        AuthenticationMethod.OAuth2ClientCredentials => _tokenStorage.GetToken(serviceDetail.Alias) != null,
+        AuthenticationMethod.OAuth2AuthorizationCode => StoredTokenExists(serviceDetail),
+        AuthenticationMethod.OAuth2ClientCredentials => StoredTokenExists(serviceDetail),
         AuthenticationMethod.ApiKey => !string.IsNullOrEmpty(serviceDetail.ApiKey),
         _ => false
     };
+
+    private bool StoredTokenExists(ServiceDetail serviceDetail) => _tokenStorage.GetToken(serviceDetail.Alias) != null;
 }

--- a/src/Umbraco.AuthorizedServices/Controllers/AuthorizedServiceController.cs
+++ b/src/Umbraco.AuthorizedServices/Controllers/AuthorizedServiceController.cs
@@ -59,7 +59,7 @@ public class AuthorizedServiceController : BackOfficeNotificationsController
         bool isAuthorized = CheckAuthorizationStatus(serviceDetail);
 
         string? authorizationUrl = null;
-        if (serviceDetail.AuthenticationMethod == AuthenticationMethod.OAuth2)
+        if (serviceDetail.AuthenticationMethod == AuthenticationMethod.OAuth2AuthorizationCode)
         {
             if (!isAuthorized)
             {
@@ -153,7 +153,7 @@ public class AuthorizedServiceController : BackOfficeNotificationsController
         ServiceDetail serviceDetail = _serviceDetailOptions.Get(model.Alias);
 
         Models.AuthorizationResult result = await _serviceAuthorizer
-            .AuthorizeServiceAsync(serviceDetail.Alias, string.Empty, string.Empty, string.Empty);
+            .AuthorizeOAuth2ClientCredentialsServiceAsync(serviceDetail.Alias);
 
         if (result.Success)
         {
@@ -166,7 +166,7 @@ public class AuthorizedServiceController : BackOfficeNotificationsController
     private bool CheckAuthorizationStatus(ServiceDetail serviceDetail) => serviceDetail.AuthenticationMethod switch
     {
         AuthenticationMethod.OAuth1 => false,
-        AuthenticationMethod.OAuth2 => _tokenStorage.GetToken(serviceDetail.Alias) != null,
+        AuthenticationMethod.OAuth2AuthorizationCode => _tokenStorage.GetToken(serviceDetail.Alias) != null,
         AuthenticationMethod.OAuth2ClientCredentials => _tokenStorage.GetToken(serviceDetail.Alias) != null,
         AuthenticationMethod.ApiKey => !string.IsNullOrEmpty(serviceDetail.ApiKey),
         _ => false

--- a/src/Umbraco.AuthorizedServices/Controllers/AuthorizedServiceResponseController.cs
+++ b/src/Umbraco.AuthorizedServices/Controllers/AuthorizedServiceResponseController.cs
@@ -50,7 +50,7 @@ public class AuthorizedServiceResponseController : UmbracoApiController
         var redirectUri = HttpContext.GetAuthorizedServiceRedirectUri();
         var codeVerifier = cachedAuthorizationPayload.CodeVerifier;
         _authorizedServiceAuthorizationPayloadCache.Remove(stateParts[0]);
-        AuthorizationResult result = await _serviceAuthorizer.AuthorizeServiceAsync(serviceAlias, code, redirectUri, codeVerifier);
+        AuthorizationResult result = await _serviceAuthorizer.AuthorizeOAuth2AuthorizationCodeServiceAsync(serviceAlias, code, redirectUri, codeVerifier);
 
         if (result.Success)
         {

--- a/src/Umbraco.AuthorizedServices/Models/AuthorizedServiceDisplay.cs
+++ b/src/Umbraco.AuthorizedServices/Models/AuthorizedServiceDisplay.cs
@@ -37,7 +37,7 @@ public class AuthorizedServiceDisplay
     /// Gets or sets the service's authentication method.
     /// </summary>
     [DataMember(Name = "authenticationMethod")]
-    public string AuthenticationMethod { get; set; } = Configuration.AuthenticationMethod.OAuth2.ToString();
+    public string AuthenticationMethod { get; set; } = Configuration.AuthenticationMethod.OAuth2AuthorizationCode.ToString();
 
     /// <summary>
     /// Gets or sets a sample GET request for the service, used for verification.

--- a/src/Umbraco.AuthorizedServices/Models/Request/GenerateToken.cs
+++ b/src/Umbraco.AuthorizedServices/Models/Request/GenerateToken.cs
@@ -1,0 +1,9 @@
+namespace Umbraco.AuthorizedServices.Models.Request;
+
+public class GenerateToken
+{
+    /// <summary>
+    /// Gets or sets the service alias.
+    /// </summary>
+    public string Alias { get; set; } = string.Empty;
+}

--- a/src/Umbraco.AuthorizedServices/Services/IAuthorizationParametersBuilder.cs
+++ b/src/Umbraco.AuthorizedServices/Services/IAuthorizationParametersBuilder.cs
@@ -8,12 +8,19 @@ namespace Umbraco.AuthorizedServices.Services;
 public interface IAuthorizationParametersBuilder
 {
     /// <summary>
-    /// Builds the the parameter dictionary used in authorization requests.
+    /// Builds the parameter dictionary used in OAuth2AuthorizationCode authorization requests.
     /// </summary>
     /// <param name="serviceDetail">The service detail.</param>
     /// <param name="authorizationCode">The authorization code.</param>
     /// <param name="redirectUri">The redirect URL.</param>
     /// <param name="codeVerifier">The code verifier that was hashed and sent as code challenge.</param>
     /// <returns>A dictionary containing the authorization parameters.</returns>
-    Dictionary<string, string> BuildParameters(ServiceDetail serviceDetail, string authorizationCode, string redirectUri, string codeVerifier);
+    Dictionary<string, string> BuildParametersForOAuth2AuthorizationCode(ServiceDetail serviceDetail, string authorizationCode, string redirectUri, string codeVerifier);
+
+    /// <summary>
+    /// Builds the parameter dictionary used in OAuth2ClientCredentials authorization requests.
+    /// </summary>
+    /// <param name="serviceDetail">The service detail.</param>
+    /// <returns>A dictionary containing the authorization parameters.</returns>
+    Dictionary<string, string> BuildParametersForOAuth2ClientCredentials(ServiceDetail serviceDetail);
 }

--- a/src/Umbraco.AuthorizedServices/Services/IAuthorizedServiceAuthorizer.cs
+++ b/src/Umbraco.AuthorizedServices/Services/IAuthorizedServiceAuthorizer.cs
@@ -8,12 +8,19 @@ namespace Umbraco.AuthorizedServices.Services;
 public interface IAuthorizedServiceAuthorizer
 {
     /// <summary>
-    /// Authorizises access to an external service.
+    /// Authorizes access to an external service using OAuth2AuthorizationCode authentication method.
     /// </summary>
     /// <param name="serviceAlias">The service alias.</param>
     /// <param name="authorizationCode">The authorization code.</param>
     /// <param name="redirectUri">The redirect URL.</param>
     /// <param name="codeVerifier">The string used to validate requests for OAuth with PKCE flows.</param>
     /// <returns>A <see cref="Task{AuthorizationResult}"/> representing the result of the asynchronous operation.</returns>
-    Task<AuthorizationResult> AuthorizeServiceAsync(string serviceAlias, string authorizationCode, string redirectUri, string codeVerifier);
+    Task<AuthorizationResult> AuthorizeOAuth2AuthorizationCodeServiceAsync(string serviceAlias, string authorizationCode, string redirectUri, string codeVerifier);
+
+    /// <summary>
+    /// Authorizes access to an external service using OAuth2ClientCredentials authentication method.
+    /// </summary>
+    /// <param name="serviceAlias">The service alias.</param>
+    /// <returns>A <see cref="Task{AuthorizationResult}"/> representing the result of the asynchronous operation.</returns>
+    Task<AuthorizationResult> AuthorizeOAuth2ClientCredentialsServiceAsync(string serviceAlias);
 }

--- a/src/Umbraco.AuthorizedServices/Services/Implement/AuthorizationParametersBuilder.cs
+++ b/src/Umbraco.AuthorizedServices/Services/Implement/AuthorizationParametersBuilder.cs
@@ -4,29 +4,9 @@ namespace Umbraco.AuthorizedServices.Services.Implement;
 
 internal sealed class AuthorizationParametersBuilder : IAuthorizationParametersBuilder
 {
-    public Dictionary<string, string> BuildParameters(ServiceDetail serviceDetail, string authorizationCode, string redirectUri, string codeVerifier)
+    public Dictionary<string, string> BuildParametersForOAuth2AuthorizationCode(ServiceDetail serviceDetail, string authorizationCode, string redirectUri, string codeVerifier)
     {
-        var parametersDictionary = new Dictionary<string, string>();
-
-        if (serviceDetail.IncludeScopesInAuthorizationRequest)
-        {
-            parametersDictionary.Add("scope", serviceDetail.Scopes);
-        }
-
-        if (serviceDetail.AuthenticationMethod == AuthenticationMethod.OAuth2ClientCredentials)
-        {
-            parametersDictionary.Add("grant_type", "client_credentials");
-
-            if (serviceDetail.ClientCredentialsProvision == ClientCredentialsProvision.RequestBody)
-            {
-                parametersDictionary.Add("client_id", serviceDetail.ClientId);
-                parametersDictionary.Add("client_secret", serviceDetail.ClientSecret);
-            }
-
-            return parametersDictionary;
-        }
-
-        parametersDictionary = new Dictionary<string, string>
+        var parametersDictionary = new Dictionary<string, string>
             {
                 { "grant_type", "authorization_code" },
                 { "client_id", serviceDetail.ClientId },
@@ -38,6 +18,27 @@ internal sealed class AuthorizationParametersBuilder : IAuthorizationParametersB
         if (serviceDetail.UseProofKeyForCodeExchange)
         {
             parametersDictionary.Add("code_verifier", codeVerifier);
+        }
+
+        return parametersDictionary;
+    }
+
+    public Dictionary<string, string> BuildParametersForOAuth2ClientCredentials(ServiceDetail serviceDetail)
+    {
+        var parametersDictionary = new Dictionary<string, string>()
+        {
+            { "grant_type", "client_credentials" }
+        };
+
+        if (serviceDetail.ClientCredentialsProvision == ClientCredentialsProvision.RequestBody)
+        {
+            parametersDictionary.Add("client_id", serviceDetail.ClientId);
+            parametersDictionary.Add("client_secret", serviceDetail.ClientSecret);
+        }
+
+        if (serviceDetail.IncludeScopesInAuthorizationRequest)
+        {
+            parametersDictionary.Add("scope", serviceDetail.Scopes);
         }
 
         return parametersDictionary;

--- a/src/Umbraco.AuthorizedServices/Services/Implement/AuthorizationParametersBuilder.cs
+++ b/src/Umbraco.AuthorizedServices/Services/Implement/AuthorizationParametersBuilder.cs
@@ -6,7 +6,27 @@ internal sealed class AuthorizationParametersBuilder : IAuthorizationParametersB
 {
     public Dictionary<string, string> BuildParameters(ServiceDetail serviceDetail, string authorizationCode, string redirectUri, string codeVerifier)
     {
-        var parametersDictionary = new Dictionary<string, string>
+        var parametersDictionary = new Dictionary<string, string>();
+
+        if (serviceDetail.IncludeScopesInAuthorizationRequest)
+        {
+            parametersDictionary.Add("scope", serviceDetail.Scopes);
+        }
+
+        if (serviceDetail.AuthenticationMethod == AuthenticationMethod.OAuth2ClientCredentials)
+        {
+            parametersDictionary.Add("grant_type", "client_credentials");
+
+            if (serviceDetail.ClientCredentialsProvision == ClientCredentialsProvision.RequestBody)
+            {
+                parametersDictionary.Add("client_id", serviceDetail.ClientId);
+                parametersDictionary.Add("client_secret", serviceDetail.ClientSecret);
+            }
+
+            return parametersDictionary;
+        }
+
+        parametersDictionary = new Dictionary<string, string>
             {
                 { "grant_type", "authorization_code" },
                 { "client_id", serviceDetail.ClientId },

--- a/src/Umbraco.AuthorizedServices/Services/Implement/AuthorizationRequestSender.cs
+++ b/src/Umbraco.AuthorizedServices/Services/Implement/AuthorizationRequestSender.cs
@@ -16,7 +16,9 @@ internal sealed class AuthorizationRequestSender : IAuthorizationRequestSender
 
         var url = serviceDetail.GetTokenHost() + serviceDetail.RequestTokenPath;
 
-        if (serviceDetail.AuthorizationRequestRequiresAuthorizationHeaderWithBasicToken)
+        if ((serviceDetail.AuthenticationMethod == AuthenticationMethod.OAuth2ClientCredentials
+                && serviceDetail.ClientCredentialsProvision == ClientCredentialsProvision.AuthHeader)
+            || serviceDetail.AuthorizationRequestRequiresAuthorizationHeaderWithBasicToken)
         {
             BuildBasicTokenHeader(httpClient, serviceDetail);
         }

--- a/src/Umbraco.AuthorizedServices/Umbraco.AuthorizedServices.csproj
+++ b/src/Umbraco.AuthorizedServices/Umbraco.AuthorizedServices.csproj
@@ -31,7 +31,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="docs\NuGetReadMe.md" Pack="true" PackagePath="\"/>
+    <None Include="docs\NuGetReadMe.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
   <!-- Build client assets using NPM -->
@@ -40,6 +40,7 @@
 	<WriteLinesToFile File="ClientApp\gulp\config.outputPath.js" Lines="export const outputPath = '../$(IntermediateOutputPath.Replace('\', '/'))clientassets';" Overwrite="true" WriteOnlyWhenDifferent="true" />
   </Target>
   <ItemGroup>
+    <ClientAssetsInputs Remove="ClientApp\src\backoffice\AuthorizedServices\authorizedservice.constants.ts" />
     <ClientAssetsInputs Remove="ClientApp\src\css\style.css" />
   </ItemGroup>
 

--- a/src/Umbraco.AuthorizedServices/appsettings-schema.Umbraco.AuthorizedServices.json
+++ b/src/Umbraco.AuthorizedServices/appsettings-schema.Umbraco.AuthorizedServices.json
@@ -50,6 +50,10 @@
           "type": "string",
           "description": "Gets or sets the authentication method for the service."
         },
+        "ClientCredentialsProvision": {
+          "type": "string",
+          "description": "Gets or sets the provision type for OAuth2 client credentials authorization."
+        },
         "ApiHost": {
           "type": "string",
           "description": "Gets or sets the host name for the service's API."
@@ -112,6 +116,10 @@
         "Scopes": {
           "type": "string",
           "description": "Gets or sets the scopes required for working with the service."
+        },
+        "IncludeScopesInAuthorizationRequest": {
+          "type": "boolean",
+          "description": "Gets or sets whether the scopes should be included in the request body during the authorization request."
         },
         "AccessTokenResponseKey": {
           "type": "string",

--- a/tests/Umbraco.AuthorizedServices.Tests/Services/AuthorizationParametersBuilderTests.cs
+++ b/tests/Umbraco.AuthorizedServices.Tests/Services/AuthorizationParametersBuilderTests.cs
@@ -5,22 +5,27 @@ namespace Umbraco.AuthorizedServices.Tests.Services;
 
 internal class AuthorizationParametersBuilderTests
 {
+    private readonly ServiceDetail _serviceDetail = new ServiceDetail();
+
+    [SetUp]
+    public void Setup()
+    {
+        _serviceDetail.ClientId = "TestClientId";
+        _serviceDetail.ClientSecret = "TestClientSecret";
+    }
+
+
     [Test]
-    public void BuildParameters_ReturnsExpectedResult()
+    public void BuildParameters_ForOAuth2AuthorizationCode_ReturnsExpectedResult()
     {
         // Arrange
-        var serviceDetail = new ServiceDetail
-        {
-            ClientId = "TestClientId",
-            ClientSecret = "TestClientSecret"
-        };
         const string AuthorizationCode = "1234";
         const string RedirectUrl = "https://test.url";
         const string CodeVerifier = "TestCodeVerifier";
         var sut = new AuthorizationParametersBuilder();
 
         // Act
-        Dictionary<string, string> result = sut.BuildParameters(serviceDetail, AuthorizationCode, RedirectUrl, CodeVerifier);
+        Dictionary<string, string> result = sut.BuildParametersForOAuth2AuthorizationCode(_serviceDetail, AuthorizationCode, RedirectUrl, CodeVerifier);
 
         // Assert
         result.Count.Should().Be(5);
@@ -30,4 +35,80 @@ internal class AuthorizationParametersBuilderTests
         result["code"].Should().Be(AuthorizationCode);
         result["redirect_uri"].Should().Be(RedirectUrl);
     }
+
+    [Test]
+    public void BuildParameters_ForOAuth2AuthorizationCode_WithCodeVerifier_ReturnsExpectedResult()
+    {
+        // Arrange
+        _serviceDetail.UseProofKeyForCodeExchange = true;
+
+        const string AuthorizationCode = "1234";
+        const string RedirectUrl = "https://test.url";
+        const string CodeVerifier = "TestCodeVerifier";
+        var sut = new AuthorizationParametersBuilder();
+
+        // Act
+        Dictionary<string, string> result = sut.BuildParametersForOAuth2AuthorizationCode(_serviceDetail, AuthorizationCode, RedirectUrl, CodeVerifier);
+
+        // Assert
+        result.Count.Should().Be(6);
+        result["grant_type"].Should().Be("authorization_code");
+        result["client_id"].Should().Be("TestClientId");
+        result["client_secret"].Should().Be("TestClientSecret");
+        result["code"].Should().Be(AuthorizationCode);
+        result["redirect_uri"].Should().Be(RedirectUrl);
+        result["code_verifier"].Should().Be(CodeVerifier);
+    }
+
+    [Test]
+    public void BuildParameters_ForOAuth2ClientCredentials_WithScopes_ReturnsExpectedResult()
+    {
+        // Arrange
+        _serviceDetail.IncludeScopesInAuthorizationRequest = true;
+        _serviceDetail.Scopes = "./default";
+
+        var sut = new AuthorizationParametersBuilder();
+
+        // Act
+        Dictionary<string, string> result = sut.BuildParametersForOAuth2ClientCredentials(_serviceDetail);
+
+        // Assert
+        result.Count.Should().Be(4);
+        result["grant_type"].Should().Be("client_credentials");
+        result["scope"].Should().Be("./default");
+    }
+
+    [Test]
+    public void BuildParameters_ForOAuth2ClientCredentials_ReturnsExpectedResult()
+    {
+        // Arrange
+        var sut = new AuthorizationParametersBuilder();
+
+        // Act
+        Dictionary<string, string> result = sut.BuildParametersForOAuth2ClientCredentials(_serviceDetail);
+
+        // Assert
+        result.Count.Should().Be(3);
+        result["grant_type"].Should().Be("client_credentials");
+        result["client_id"].Should().Be("TestClientId");
+        result["client_secret"].Should().Be("TestClientSecret");
+    }
+
+    [Test]
+    public void BuildParameters_ForOAuth2ClientCredentials_WithClientCredentialsProvisionInAuthHeader_ReturnsExpectedResult()
+    {
+        // Arrange
+        _serviceDetail.ClientCredentialsProvision = ClientCredentialsProvision.AuthHeader;
+
+        var sut = new AuthorizationParametersBuilder();
+
+        // Act
+        Dictionary<string, string> result = sut.BuildParametersForOAuth2ClientCredentials(_serviceDetail);
+
+        // Assert
+        result.Count.Should().Be(1);
+        result["grant_type"].Should().Be("client_credentials");
+    }
+
+
 }

--- a/tests/Umbraco.AuthorizedServices.Tests/Services/AuthorizationRequestSenderTests.cs
+++ b/tests/Umbraco.AuthorizedServices.Tests/Services/AuthorizationRequestSenderTests.cs
@@ -1,5 +1,7 @@
 using Moq.Protected;
 using System.Net;
+using System.Net.Http.Headers;
+using System.Text;
 using Umbraco.AuthorizedServices.Configuration;
 using Umbraco.AuthorizedServices.Services;
 using Umbraco.AuthorizedServices.Services.Implement;
@@ -86,6 +88,47 @@ internal class AuthorizationRequestSenderTests
                 ItExpr.IsAny<CancellationToken>());
     }
 
+    [Test]
+    public async Task SendRequest_ForOAuth2ClientCredentialsWithClientCredentialsProvisionInHeader_SendsRequest()
+    {
+        // Arrange
+        var serviceDetail = new ServiceDetail
+        {
+            TokenHost = "https://service.url",
+            ClientId = "TestClientId",
+            ClientSecret = "TestClientSecret",
+            RequestTokenFormat = TokenRequestContentFormat.FormUrlEncoded,
+            AuthenticationMethod = AuthenticationMethod.OAuth2ClientCredentials,
+            ClientCredentialsProvision = ClientCredentialsProvision.AuthHeader
+        };
+        var httpMessageHandlerMock = new Mock<HttpMessageHandler>();
+        httpMessageHandlerMock.Protected()
+            .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(new HttpResponseMessage { StatusCode = HttpStatusCode.OK });
+        var clientFactoryMock = new Mock<IAuthorizationClientFactory>();
+        clientFactoryMock
+            .Setup(x => x.CreateClient())
+            .Returns(new HttpClient(httpMessageHandlerMock.Object));
+        var parameters = new Dictionary<string, string>
+        {
+            { "foo", "bar" },
+            { "baz", "buzz" }
+        };
+        var sut = new AuthorizationRequestSender(clientFactoryMock.Object);
+
+        // Act
+        await sut.SendRequest(serviceDetail, parameters);
+
+        // Assert
+        AuthenticationHeaderValue expectedAuthenticationHeader = BuildBasicAuthenticationHeader(serviceDetail);
+        httpMessageHandlerMock.Protected()
+            .Verify(
+                "SendAsync",
+                Times.Once(),
+                ItExpr.Is<HttpRequestMessage>(x => IsAuthenticationHeaderValid(x, expectedAuthenticationHeader)),
+                ItExpr.IsAny<CancellationToken>());
+    }
+
     private bool IsExpectedFormUrlContent(HttpContent? content, string expectedContent)
     {
         if (content as FormUrlEncodedContent is null)
@@ -97,6 +140,19 @@ internal class AuthorizationRequestSenderTests
         var contentString = formUrlEncodedContent.ReadAsStringAsync().Result;
 
         return contentString == expectedContent;
+    }
+
+    private bool IsAuthenticationHeaderValid(HttpRequestMessage requestMessage, AuthenticationHeaderValue expectedHeaderValue) =>
+        requestMessage.Headers.Authorization is not null
+        && requestMessage.Headers.Authorization.Parameter is not null
+        && requestMessage.Headers.Authorization.Parameter == expectedHeaderValue.Parameter;
+
+    private AuthenticationHeaderValue BuildBasicAuthenticationHeader(ServiceDetail serviceDetail)
+    {
+        var authenticationString = $"{serviceDetail.ClientId}:{serviceDetail.ClientSecret}";
+        var base64String = Convert.ToBase64String(Encoding.UTF8.GetBytes(authenticationString));
+
+        return new AuthenticationHeaderValue("Basic", base64String);
     }
 
 }

--- a/tests/Umbraco.AuthorizedServices.Tests/Services/AuthorizedServiceAuthorizerTests.cs
+++ b/tests/Umbraco.AuthorizedServices.Tests/Services/AuthorizedServiceAuthorizerTests.cs
@@ -24,7 +24,7 @@ internal class AuthorizedServiceAuthorizerTests : AuthorizedServiceTestsBase
         AuthorizedServiceAuthorizer sut = CreateService();
 
         // Act
-        AuthorizationResult result = await sut.AuthorizeServiceAsync(ServiceAlias, "1234", "https://test.url/handle-auth", "5678");
+        AuthorizationResult result = await sut.AuthorizeOAuth2AuthorizationCodeServiceAsync(ServiceAlias, "1234", "https://test.url/handle-auth", "5678");
 
         // Assert
         result.Success.Should().BeTrue();
@@ -40,7 +40,7 @@ internal class AuthorizedServiceAuthorizerTests : AuthorizedServiceTestsBase
         AuthorizedServiceAuthorizer sut = CreateService(withSuccessReponse: false);
 
         // Act
-        Func<Task> act = () => sut.AuthorizeServiceAsync(ServiceAlias, "1234", "https://test.url/handle-auth", "5678");
+        Func<Task> act = () => sut.AuthorizeOAuth2AuthorizationCodeServiceAsync(ServiceAlias, "1234", "https://test.url/handle-auth", "5678");
 
         // Assert
         await act.Should().ThrowAsync<AuthorizedServiceHttpException>();


### PR DESCRIPTION
Current PR contains the implementation of the OAuth2 Client Credentials feature. Client Credentials component is a protocol for exchanging the `client_id`, `client_secret` pair identifying a service app for an access token; opposed to regular OAuth2 flow, where users got authorized after entering their credentials.

There are two implementations for this component, 
- one that involves sending the `client_id`/`client_secret` in the request body
-  and another one that uses a base64 encoding of the string formed using this template: `<client_id>:<client_secret>`. In the second scenario, the base64 string will be added to the authorization header.
Both implementations imply the use of `client_credentials` grant type.

The added updates have been tested with Salesforce and Microsoft. On both services I have created and configured specific apps, retrieving the `client_id` and `client_secret` values.

While naming and applying other conventions, I took inspiration from a VS Code Thunder Client/Postman component called `Generate Client Token`:
![image](https://github.com/umbraco/Umbraco.AuthorizedServices/assets/95346674/cdc5edd0-a2db-420f-858d-d22d2373dbf4)

Updates included:
- extended the list of authentication methods by adding `OAuth2ClientCredentials`.
- added a new property to the `ServiceDetail` object, called `ClientCredentialsProvision` to switch between the two options: `AuthHeader` or `RequestBody`.
- defined a TypeScript enum to store the `AuthenticationMethod` - a clone of `AuthenticationMethod` from server-side. As in the future we might end up with use cases that would require the UI behavior to change, I thought this will make easy checking the authentication methods without using string comparison.
- update the `Authorize Service` event so that in this case a server call will be made to retrieve the access token.
- Microsoft requires the scopes to be included in the request, so I've added the `IncludeScopesInAuthorizationRequst` property.

For authorization I've kept the `IAuthorizedServiceAuthorized.AuthorizeServiceAsync` method and passed only the service alias. In the method implementation, depending on the service details, proper actions will be taken.

