### PR TITLE
Feature/manually add api key

### DIFF
--- a/src/Umbraco.AuthorizedServices/AuthorizedServicesComposer.cs
+++ b/src/Umbraco.AuthorizedServices/AuthorizedServicesComposer.cs
@@ -57,6 +57,7 @@ internal class AuthorizedServicesComposer : IComposer
 
         builder.Services.AddUnique<ITokenFactory, TokenFactory>();
         builder.Services.AddUnique<ITokenStorage, DatabaseTokenStorage>();
+        builder.Services.AddUnique<IKeyStorage, DatabaseKeyStorage>();
 
         builder.Services.AddSingleton<JsonSerializerFactory>();
     }

--- a/src/Umbraco.AuthorizedServices/ClientApp/src/backoffice/AuthorizedServices/edit.controller.ts
+++ b/src/Umbraco.AuthorizedServices/ClientApp/src/backoffice/AuthorizedServices/edit.controller.ts
@@ -14,11 +14,12 @@ function AuthorizedServiceEditController(this: any, $routeParams, $location, aut
         vm.isAuthorized = serviceData.isAuthorized;
         vm.authenticationMethod = serviceData.authenticationMethod;
         vm.canManuallyProvideToken = serviceData.canManuallyProvideToken;
+        vm.canManuallyProvideApiKey = serviceData.canManuallyProvideApiKey;
         vm.authorizationUrl = serviceData.authorizationUrl;
         vm.sampleRequest = serviceData.sampleRequest;
         vm.sampleRequestResponse = null;
         vm.settings = serviceData.settings;
-        vm.isApiKeyBasedAuthenticationMethod = serviceData.authenticationMethod === AuthenticationMethod.ApiKey;
+        vm.isOAuthBasedAuthenticationMethod = serviceData.authenticationMethod !== AuthenticationMethod.ApiKey;
       });
   }
 
@@ -62,6 +63,19 @@ function AuthorizedServiceEditController(this: any, $routeParams, $location, aut
         .then(function () {
           notificationsService.success("Authorized Services", "The '" + vm.displayName + "' service access token has been saved.");
           inAccessToken.value = "";
+          loadServiceDetails(serviceAlias);
+        });
+    }
+  }
+
+  vm.saveApiKey = function () {
+    let inApiKey = <HTMLInputElement>document.getElementById("inApiKey");
+
+    if (inApiKey) {
+      authorizedServiceResource.saveApiKey(serviceAlias, inApiKey.value)
+        .then(function () {
+          notificationsService.success("Authorized Services", "The '" + vm.displayName + "' service API key has been saved.");
+          inApiKey.value = "";
           loadServiceDetails(serviceAlias);
         });
     }

--- a/src/Umbraco.AuthorizedServices/ClientApp/src/backoffice/AuthorizedServices/edit.html
+++ b/src/Umbraco.AuthorizedServices/ClientApp/src/backoffice/AuthorizedServices/edit.html
@@ -77,7 +77,7 @@
               <uui-icon slot="icon" name="add"></uui-icon>
               <p class="auth-srv">Enter service API key</p>
               <p>
-                This service is configured indicating that an API key can be generated via the service's developer portal.
+                This service is configured indicating that an API key can be created via the service's developer portal.
                 Once you have obtained one you can copy and paste it here to authorize the service.
               </p>
               <div>

--- a/src/Umbraco.AuthorizedServices/ClientApp/src/backoffice/AuthorizedServices/edit.html
+++ b/src/Umbraco.AuthorizedServices/ClientApp/src/backoffice/AuthorizedServices/edit.html
@@ -24,7 +24,8 @@
                             action="vm.sendSampleRequest()"
                             type="button"
                             label="Verify Sample Request"></umb-button>
-                <umb-button ng-if="!vm.isApiKeyBasedAuthenticationMethod"
+                <umb-button ng-if="vm.isOAuthBasedAuthenticationMethod
+                            || (!vm.isOAuthBasedAuthenticationMethod && vm.canManuallyProvideApiKey)"
                             action="vm.revokeAccess()"
                             type="button"
                             button-style="danger"
@@ -47,6 +48,7 @@
           </uui-icon-registry-essential>
         </umb-box-content>
       </umb-box>
+      <!-- Provide Token Section -->
       <umb-box ng-if="vm.canManuallyProvideToken">
         <umb-box-header title="Provide Token"></umb-box-header>
         <umb-box-content>
@@ -58,6 +60,29 @@
               <div>
                 <uui-input id="inAccessToken" type="text" name="inAccessToken" style="width: 40%;font-size:14px;"></uui-input>
                 <umb-button action="vm.saveAccessToken()"
+                            type="button"
+                            button-style="primary"
+                            label="Save"></umb-button>
+              </div>
+            </uui-card-content-node>
+          </uui-icon-registry-essential>
+        </umb-box-content>
+      </umb-box>
+      <!-- Provide Key Section -->
+      <umb-box ng-if="vm.canManuallyProvideApiKey">
+        <umb-box-header title="Provide API key"></umb-box-header>
+        <umb-box-content>
+          <uui-icon-registry-essential>
+            <uui-card-content-node name="API Key">
+              <uui-icon slot="icon" name="add"></uui-icon>
+              <p class="auth-srv">Enter service API key</p>
+              <p>
+                This service is configured indicating that an API key can be generated via the service's developer portal.
+                Once you have obtained one you can copy and paste it here to authorize the service.
+              </p>
+              <div>
+                <uui-input id="inApiKey" type="text" name="inApiKey" style="width: 40%;font-size:14px;"></uui-input>
+                <umb-button action="vm.saveApiKey()"
                             type="button"
                             button-style="primary"
                             label="Save"></umb-button>

--- a/src/Umbraco.AuthorizedServices/ClientApp/src/resources/authorizedservice.resource.ts
+++ b/src/Umbraco.AuthorizedServices/ClientApp/src/resources/authorizedservice.resource.ts
@@ -17,6 +17,9 @@ function authorizedServiceResource($q, $http) {
     saveToken: function (alias: string, token: string) {
       return $http.post(apiRoot + "SaveToken", { alias: alias, token: token });
     },
+    saveApiKey: function (alias: string, apiKey: string) {
+      return $http.post(apiRoot + "SaveApiKey", { alias: alias, apiKey: apiKey });
+    },
     generateToken: function (alias: string) {
       return $http.post(apiRoot + "GenerateToken", { alias: alias });
     }

--- a/src/Umbraco.AuthorizedServices/Configuration/AuthorizedServiceSettings.cs
+++ b/src/Umbraco.AuthorizedServices/Configuration/AuthorizedServiceSettings.cs
@@ -133,7 +133,7 @@ public class ServiceDetail : ServiceSummary
     public string TokenHost { get; set; } = string.Empty;
 
     /// <summary>
-    /// Get or sets a value indicating whether an administrator editor can manually provide tokens via the backoffice.
+    /// Get or sets a value indicating whether an administrator can manually provide tokens via the backoffice.
     /// </summary>
     public bool CanManuallyProvideToken { get; set; }
 

--- a/src/Umbraco.AuthorizedServices/Configuration/AuthorizedServiceSettings.cs
+++ b/src/Umbraco.AuthorizedServices/Configuration/AuthorizedServiceSettings.cs
@@ -133,9 +133,14 @@ public class ServiceDetail : ServiceSummary
     public string TokenHost { get; set; } = string.Empty;
 
     /// <summary>
-    /// Get or sets a value indicating whether an adminsitrator editor can manually provide tokens via the backoffice.
+    /// Get or sets a value indicating whether an administrator editor can manually provide tokens via the backoffice.
     /// </summary>
     public bool CanManuallyProvideToken { get; set; }
+
+    /// <summary>
+    /// Get or sets a value indicating whether an administrator editor can manually provide API keys via the backoffice.
+    /// </summary>
+    public bool CanManuallyProvideApiKey { get; set; }
 
     /// <summary>
     /// Gets or sets the path for requests for authentication with the service.

--- a/src/Umbraco.AuthorizedServices/Configuration/AuthorizedServiceSettings.cs
+++ b/src/Umbraco.AuthorizedServices/Configuration/AuthorizedServiceSettings.cs
@@ -138,7 +138,7 @@ public class ServiceDetail : ServiceSummary
     public bool CanManuallyProvideToken { get; set; }
 
     /// <summary>
-    /// Get or sets a value indicating whether an administrator editor can manually provide API keys via the backoffice.
+    /// Get or sets a value indicating whether an administrator can manually provide API keys via the backoffice.
     /// </summary>
     public bool CanManuallyProvideApiKey { get; set; }
 

--- a/src/Umbraco.AuthorizedServices/Constants.cs
+++ b/src/Umbraco.AuthorizedServices/Constants.cs
@@ -44,10 +44,14 @@ public static class Constants
 
     public static class Migrations
     {
-        public const string TableName = "umbracoAuthorizedServiceToken";
+        public const string UmbracoAuthorizedServiceTokenTableName = "umbracoAuthorizedServiceToken";
+
+        public const string UmbracoAuthorizedServiceKeyTableName = "umbracoAuthorizedServiceKey";
 
         public const string MigrationPlan = "AuthorizedServicesDatabaseMigration";
 
-        public const string TargetState = "authorizedServices-db";
+        public const string UmbracoAuthorizedServiceTokenTargetState = "authorizedServices-token-db";
+
+        public const string UmbracoAuthorizedServiceKeyTargetState = "authorizedServices-key-db";
     }
 }

--- a/src/Umbraco.AuthorizedServices/Controllers/AuthorizedServiceController.cs
+++ b/src/Umbraco.AuthorizedServices/Controllers/AuthorizedServiceController.cs
@@ -130,8 +130,15 @@ public class AuthorizedServiceController : BackOfficeNotificationsController
     [HttpPost]
     public IActionResult RevokeAccess(RevokeAccess model)
     {
-        _tokenStorage.DeleteToken(model.Alias);
-        _keyStorage.DeleteKey(model.Alias);
+        ServiceDetail serviceDetail = _serviceDetailOptions.Get(model.Alias);
+        if (serviceDetail.AuthenticationMethod != AuthenticationMethod.ApiKey)
+        {
+            _tokenStorage.DeleteToken(model.Alias);
+        }
+        else
+        {
+            _keyStorage.DeleteKey(model.Alias);
+        }
         return Ok();
     }
 

--- a/src/Umbraco.AuthorizedServices/Migrations/AddDatabaseKeyStorageTable.cs
+++ b/src/Umbraco.AuthorizedServices/Migrations/AddDatabaseKeyStorageTable.cs
@@ -1,0 +1,26 @@
+using Microsoft.Extensions.Logging;
+using Umbraco.AuthorizedServices.Persistence.Dtos;
+using Umbraco.Cms.Infrastructure.Migrations;
+
+namespace Umbraco.AuthorizedServices.Migrations;
+
+public class AddDatabaseKeyStorageTable : MigrationBase
+{
+    public AddDatabaseKeyStorageTable(IMigrationContext context) : base(context)
+    {
+    }
+
+    protected override void Migrate()
+    {
+        Logger.LogDebug($"Running migration {nameof(AddDatabaseKeyStorageTable)}");
+
+        if (TableExists(Constants.Migrations.UmbracoAuthorizedServiceKeyTableName))
+        {
+            Logger.LogDebug($"The database table {Constants.Migrations.UmbracoAuthorizedServiceKeyTableName} already exists, skipping.");
+        }
+        else
+        {
+            Create.Table<KeyDto>().Do();
+        }
+    }
+}

--- a/src/Umbraco.AuthorizedServices/Migrations/AddDatabaseTokenStorageTable.cs
+++ b/src/Umbraco.AuthorizedServices/Migrations/AddDatabaseTokenStorageTable.cs
@@ -14,9 +14,9 @@ public class AddDatabaseTokenStorageTable : MigrationBase
     {
         Logger.LogDebug($"Running migration {nameof(AddDatabaseTokenStorageTable)}");
 
-        if (TableExists(Constants.Migrations.TableName))
+        if (TableExists(Constants.Migrations.UmbracoAuthorizedServiceTokenTableName))
         {
-            Logger.LogDebug($"The database table {Constants.Migrations.TableName} already exists, skipping.");
+            Logger.LogDebug($"The database table {Constants.Migrations.UmbracoAuthorizedServiceTokenTableName} already exists, skipping.");
         }
         else
         {

--- a/src/Umbraco.AuthorizedServices/Migrations/AuthorizedServicesMigrationPlan.cs
+++ b/src/Umbraco.AuthorizedServices/Migrations/AuthorizedServicesMigrationPlan.cs
@@ -20,6 +20,7 @@ public class AuthorizedServicesMigrationPlan : PackageMigrationPlan
     /// <inheritdoc />
     protected override void DefinePlan()
     {
-        To<AddDatabaseTokenStorageTable>(Constants.Migrations.TargetState);
+        To<AddDatabaseTokenStorageTable>(Constants.Migrations.UmbracoAuthorizedServiceTokenTargetState);
+        To<AddDatabaseKeyStorageTable>(Constants.Migrations.UmbracoAuthorizedServiceKeyTargetState);
     }
 }

--- a/src/Umbraco.AuthorizedServices/Models/AuthorizedServiceDisplay.cs
+++ b/src/Umbraco.AuthorizedServices/Models/AuthorizedServiceDisplay.cs
@@ -22,7 +22,7 @@ public class AuthorizedServiceDisplay
     public bool IsAuthorized { get; set; }
 
     /// <summary>
-    /// Get or sets a value indicating whether an administrator editor can manually provide tokens via the backoffice.
+    /// Get or sets a value indicating whether an administrator an manually provide tokens via the backoffice.
     /// </summary>
     [DataMember(Name = "canManuallyProvideToken")]
     public bool CanManuallyProvideToken { get; set; }

--- a/src/Umbraco.AuthorizedServices/Models/AuthorizedServiceDisplay.cs
+++ b/src/Umbraco.AuthorizedServices/Models/AuthorizedServiceDisplay.cs
@@ -22,10 +22,16 @@ public class AuthorizedServiceDisplay
     public bool IsAuthorized { get; set; }
 
     /// <summary>
-    /// Get or sets a value indicating whether an adminsitrator editor can manually provide tokens via the backoffice.
+    /// Get or sets a value indicating whether an administrator editor can manually provide tokens via the backoffice.
     /// </summary>
     [DataMember(Name = "canManuallyProvideToken")]
     public bool CanManuallyProvideToken { get; set; }
+
+    /// <summary>
+    /// Get or sets a value indicating whether an administrator editor can manually provide API keys via the backoffice.
+    /// </summary>
+    [DataMember(Name = "canManuallyProvideApiKey")]
+    public bool CanManuallyProvideApiKey { get; set; }
 
     /// <summary>
     /// Gets or sets the service's authorization URL.

--- a/src/Umbraco.AuthorizedServices/Models/AuthorizedServiceDisplay.cs
+++ b/src/Umbraco.AuthorizedServices/Models/AuthorizedServiceDisplay.cs
@@ -28,7 +28,7 @@ public class AuthorizedServiceDisplay
     public bool CanManuallyProvideToken { get; set; }
 
     /// <summary>
-    /// Get or sets a value indicating whether an administrator editor can manually provide API keys via the backoffice.
+    /// Get or sets a value indicating whether an administrator can manually provide API keys via the backoffice.
     /// </summary>
     [DataMember(Name = "canManuallyProvideApiKey")]
     public bool CanManuallyProvideApiKey { get; set; }

--- a/src/Umbraco.AuthorizedServices/Models/Request/AddApiKey.cs
+++ b/src/Umbraco.AuthorizedServices/Models/Request/AddApiKey.cs
@@ -1,0 +1,17 @@
+namespace Umbraco.AuthorizedServices.Models.Request;
+
+/// <summary>
+/// Defines the model used for saving a service API key via a backoffice operation.
+/// </summary>
+public class AddApiKey
+{
+    /// <summary>
+    /// Gets or sets the service alias.
+    /// </summary>
+    public string Alias { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the service API key.
+    /// </summary>
+    public string ApiKey { get; set; } = string.Empty;
+}

--- a/src/Umbraco.AuthorizedServices/Persistence/Dtos/KeyDto.cs
+++ b/src/Umbraco.AuthorizedServices/Persistence/Dtos/KeyDto.cs
@@ -1,0 +1,19 @@
+using NPoco;
+using Umbraco.Cms.Infrastructure.Persistence.DatabaseAnnotations;
+
+namespace Umbraco.AuthorizedServices.Persistence.Dtos;
+
+[TableName(Constants.Migrations.UmbracoAuthorizedServiceKeyTableName)]
+[PrimaryKey("serviceAlias", AutoIncrement = false)]
+[ExplicitColumns]
+public class KeyDto
+{
+    [Column("serviceAlias")]
+    [PrimaryKeyColumn(Name = "PK_serviceAlias", AutoIncrement = false)]
+    [Length(100)]
+    public string ServiceAlias { get; set; } = string.Empty;
+
+    [Column("apiKey")]
+    [Length(1000)]
+    public string ApiKey { get; set; } = string.Empty;
+}

--- a/src/Umbraco.AuthorizedServices/Persistence/Dtos/TokenDto.cs
+++ b/src/Umbraco.AuthorizedServices/Persistence/Dtos/TokenDto.cs
@@ -4,7 +4,7 @@ using Umbraco.Cms.Infrastructure.Persistence.DatabaseAnnotations;
 
 namespace Umbraco.AuthorizedServices.Persistence.Dtos;
 
-[TableName(Constants.Migrations.TableName)]
+[TableName(Constants.Migrations.UmbracoAuthorizedServiceTokenTableName)]
 [PrimaryKey("serviceAlias", AutoIncrement = false)]
 [ExplicitColumns]
 public class TokenDto

--- a/src/Umbraco.AuthorizedServices/Services/IAuthorizedRequestBuilder.cs
+++ b/src/Umbraco.AuthorizedServices/Services/IAuthorizedRequestBuilder.cs
@@ -33,12 +33,14 @@ public interface IAuthorizedRequestBuilder
     /// <param name="serviceDetail">The service detail.</param>
     /// <param name="path">The request path.</param>
     /// <param name="httpMethod">The HTTP method.</param>
+    /// <param name="apiKey">The authorization API key.</param>
     /// <param name="requestContent">The request data.</param>
     /// <returns>The request instance.</returns>
     HttpRequestMessage CreateRequestMessageWithApiKey<TRequest>(
         ServiceDetail serviceDetail,
         string path,
         HttpMethod httpMethod,
+        string apiKey,
         TRequest? requestContent)
         where TRequest : class;
 }

--- a/src/Umbraco.AuthorizedServices/Services/IKeyStorage.cs
+++ b/src/Umbraco.AuthorizedServices/Services/IKeyStorage.cs
@@ -1,0 +1,27 @@
+namespace Umbraco.AuthorizedServices.Services;
+
+/// <summary>
+/// Defines operations for storing API keys.
+/// </summary>
+public interface IKeyStorage
+{
+    /// <summary>
+    /// Retrieves a stored API key for a service.
+    /// </summary>
+    /// <param name="serviceAlias">The service alias.</param>
+    /// <returns>The key value (or null, if not found).</returns>
+    string? GetKey(string serviceAlias);
+
+    /// <summary>
+    /// Stores an API key for aa service.
+    /// </summary>
+    /// <param name="serviceAlias">The service alias.</param>
+    /// <param name="key">The API key.</param>
+    void SaveKey(string serviceAlias, string key);
+
+    /// <summary>
+    /// Deletes a stored API key.
+    /// </summary>
+    /// <param name="serviceAlias">The service alias.</param>
+    void DeleteKey(string serviceAlias);
+}

--- a/src/Umbraco.AuthorizedServices/Services/Implement/AuthorizedRequestBuilder.cs
+++ b/src/Umbraco.AuthorizedServices/Services/Implement/AuthorizedRequestBuilder.cs
@@ -1,10 +1,7 @@
 using System.Collections.Specialized;
-using System.IO;
 using System.Net.Http.Headers;
 using System.Text;
 using System.Web;
-using Azure.Core;
-using Microsoft.Extensions.Hosting;
 using Umbraco.AuthorizedServices.Configuration;
 using Umbraco.AuthorizedServices.Models;
 using Umbraco.Cms.Core.Serialization;
@@ -38,10 +35,11 @@ internal sealed class AuthorizedRequestBuilder : IAuthorizedRequestBuilder
        ServiceDetail serviceDetail,
        string path,
        HttpMethod httpMethod,
+       string apiKey,
        TRequest? requestContent)
        where TRequest : class
     {
-        if (string.IsNullOrWhiteSpace(serviceDetail.ApiKey))
+        if (string.IsNullOrWhiteSpace(apiKey))
         {
             throw new InvalidOperationException("Cannot create an HTTP request message for an API key request as no API key is available in configuration.");
         }
@@ -55,7 +53,7 @@ internal sealed class AuthorizedRequestBuilder : IAuthorizedRequestBuilder
         if (serviceDetail.ApiKeyProvision.Method == ApiKeyProvisionMethod.QueryString)
         {
             NameValueCollection queryStringParams = HttpUtility.ParseQueryString(requestUri.Query);
-            requestUri = new Uri($"{requestUri}{(queryStringParams.Count > 0 ? "&" : "?")}{serviceDetail.ApiKeyProvision.Key}={serviceDetail.ApiKey}");
+            requestUri = new Uri($"{requestUri}{(queryStringParams.Count > 0 ? "&" : "?")}{serviceDetail.ApiKeyProvision.Key}={apiKey}");
         }
 
         HttpRequestMessage requestMessage = CreateRequestMessage(
@@ -65,7 +63,7 @@ internal sealed class AuthorizedRequestBuilder : IAuthorizedRequestBuilder
 
         if (serviceDetail.ApiKeyProvision.Method == ApiKeyProvisionMethod.HttpHeader)
         {
-            requestMessage.Headers.Add(serviceDetail.ApiKeyProvision.Key, serviceDetail.ApiKey);
+            requestMessage.Headers.Add(serviceDetail.ApiKeyProvision.Key, apiKey);
         }
 
         AddCommonHeaders(requestMessage);

--- a/src/Umbraco.AuthorizedServices/Services/Implement/AuthorizedServiceAuthorizer.cs
+++ b/src/Umbraco.AuthorizedServices/Services/Implement/AuthorizedServiceAuthorizer.cs
@@ -15,11 +15,12 @@ internal sealed class AuthorizedServiceAuthorizer : AuthorizedServiceBase, IAuth
         AppCaches appCaches,
         ITokenFactory tokenFactory,
         ITokenStorage tokenStorage,
+        IKeyStorage keyStorage,
         IAuthorizationRequestSender authorizationRequestSender,
         ILogger<AuthorizedServiceAuthorizer> logger,
         IOptionsMonitor<ServiceDetail> serviceDetailOptions,
         IAuthorizationParametersBuilder authorizationParametersBuilder)
-        : base(appCaches, tokenFactory, tokenStorage, authorizationRequestSender, logger, serviceDetailOptions)
+        : base(appCaches, tokenFactory, tokenStorage, keyStorage, authorizationRequestSender, logger, serviceDetailOptions)
     {
         _authorizationParametersBuilder = authorizationParametersBuilder;
     }

--- a/src/Umbraco.AuthorizedServices/Services/Implement/AuthorizedServiceBase.cs
+++ b/src/Umbraco.AuthorizedServices/Services/Implement/AuthorizedServiceBase.cs
@@ -16,6 +16,7 @@ internal abstract class AuthorizedServiceBase
         AppCaches appCaches,
         ITokenFactory tokenFactory,
         ITokenStorage tokenStorage,
+        IKeyStorage keyStorage,
         IAuthorizationRequestSender authorizationRequestSender,
         ILogger logger,
         IOptionsMonitor<ServiceDetail> serviceDetailOptions)
@@ -23,6 +24,7 @@ internal abstract class AuthorizedServiceBase
         AppCaches = appCaches;
         _tokenFactory = tokenFactory;
         TokenStorage = tokenStorage;
+        KeyStorage = keyStorage;
         AuthorizationRequestSender = authorizationRequestSender;
         Logger = logger;
         _serviceDetailOptions = serviceDetailOptions;
@@ -31,6 +33,8 @@ internal abstract class AuthorizedServiceBase
     protected AppCaches AppCaches { get; }
 
     protected ITokenStorage TokenStorage { get; }
+
+    protected IKeyStorage KeyStorage { get; }
 
     protected IAuthorizationRequestSender AuthorizationRequestSender { get; }
 

--- a/src/Umbraco.AuthorizedServices/Services/Implement/AuthorizedServiceCaller.cs
+++ b/src/Umbraco.AuthorizedServices/Services/Implement/AuthorizedServiceCaller.cs
@@ -81,13 +81,12 @@ internal sealed class AuthorizedServiceCaller : AuthorizedServiceBase, IAuthoriz
         HttpRequestMessage requestMessage;
         if (serviceDetail.AuthenticationMethod == AuthenticationMethod.ApiKey)
         {
+            string? key = KeyStorage.GetKey(serviceAlias);
             requestMessage = _authorizedRequestBuilder.CreateRequestMessageWithApiKey(
                 serviceDetail,
                 path,
                 httpMethod,
-                string.IsNullOrEmpty(serviceDetail.ApiKey)
-                    ? KeyStorage.GetKey(serviceAlias) ?? string.Empty
-                    : serviceDetail.ApiKey,
+                key is not null ? key : (!string.IsNullOrEmpty(serviceDetail.ApiKey) ? serviceDetail.ApiKey : string.Empty),
                 requestContent);
         }
         else
@@ -119,7 +118,10 @@ internal sealed class AuthorizedServiceCaller : AuthorizedServiceBase, IAuthoriz
     public string? GetApiKey(string serviceAlias)
     {
         ServiceDetail serviceDetail = GetServiceDetail(serviceAlias);
-        return serviceDetail?.ApiKey;
+        string? key = KeyStorage.GetKey(serviceAlias);
+        return key is not null
+            ? key
+            : serviceDetail?.ApiKey;
     }
 
     public string? GetToken(string serviceAlias)

--- a/src/Umbraco.AuthorizedServices/Services/Implement/AuthorizedServiceCaller.cs
+++ b/src/Umbraco.AuthorizedServices/Services/Implement/AuthorizedServiceCaller.cs
@@ -21,6 +21,7 @@ internal sealed class AuthorizedServiceCaller : AuthorizedServiceBase, IAuthoriz
         AppCaches appCaches,
         ITokenFactory tokenFactory,
         ITokenStorage tokenStorage,
+        IKeyStorage keyStorage,
         IAuthorizationRequestSender authorizationRequestSender,
         ILogger<AuthorizedServiceCaller> logger,
         IOptionsMonitor<ServiceDetail> serviceDetailOptions,
@@ -28,7 +29,7 @@ internal sealed class AuthorizedServiceCaller : AuthorizedServiceBase, IAuthoriz
         JsonSerializerFactory jsonSerializerFactory,
         IAuthorizedRequestBuilder authorizedRequestBuilder,
         IRefreshTokenParametersBuilder refreshTokenParametersBuilder)
-        : base(appCaches, tokenFactory, tokenStorage, authorizationRequestSender, logger, serviceDetailOptions)
+        : base(appCaches, tokenFactory, tokenStorage, keyStorage, authorizationRequestSender, logger, serviceDetailOptions)
     {
         _httpClientFactory = httpClientFactory;
         _jsonSerializerFactory = jsonSerializerFactory;
@@ -80,7 +81,14 @@ internal sealed class AuthorizedServiceCaller : AuthorizedServiceBase, IAuthoriz
         HttpRequestMessage requestMessage;
         if (serviceDetail.AuthenticationMethod == AuthenticationMethod.ApiKey)
         {
-            requestMessage = _authorizedRequestBuilder.CreateRequestMessageWithApiKey(serviceDetail, path, httpMethod, requestContent);
+            requestMessage = _authorizedRequestBuilder.CreateRequestMessageWithApiKey(
+                serviceDetail,
+                path,
+                httpMethod,
+                string.IsNullOrEmpty(serviceDetail.ApiKey)
+                    ? KeyStorage.GetKey(serviceAlias) ?? string.Empty
+                    : serviceDetail.ApiKey,
+                requestContent);
         }
         else
         {

--- a/src/Umbraco.AuthorizedServices/Services/Implement/DatabaseAuthorizationParameterStorageBase.cs
+++ b/src/Umbraco.AuthorizedServices/Services/Implement/DatabaseAuthorizationParameterStorageBase.cs
@@ -5,12 +5,6 @@ namespace Umbraco.AuthorizedServices.Services.Implement;
 
 internal class DatabaseAuthorizationParameterStorageBase
 {
-    protected IScopeProvider ScopeProvider { get; }
-
-    protected ISecretEncryptor Encryptor { get; }
-
-    protected ILogger<DatabaseAuthorizationParameterStorageBase> Logger { get; }
-
     public DatabaseAuthorizationParameterStorageBase(
         IScopeProvider scopeProvider,
         ISecretEncryptor encryptor,
@@ -20,4 +14,10 @@ internal class DatabaseAuthorizationParameterStorageBase
         Encryptor = encryptor;
         Logger = logger;
     }
+
+    protected IScopeProvider ScopeProvider { get; }
+
+    protected ISecretEncryptor Encryptor { get; }
+
+    protected ILogger<DatabaseAuthorizationParameterStorageBase> Logger { get; }
 }

--- a/src/Umbraco.AuthorizedServices/Services/Implement/DatabaseAuthorizationParameterStorageBase.cs
+++ b/src/Umbraco.AuthorizedServices/Services/Implement/DatabaseAuthorizationParameterStorageBase.cs
@@ -1,0 +1,23 @@
+using Microsoft.Extensions.Logging;
+using Umbraco.Cms.Infrastructure.Scoping;
+
+namespace Umbraco.AuthorizedServices.Services.Implement;
+
+internal class DatabaseAuthorizationParameterStorageBase
+{
+    protected IScopeProvider ScopeProvider { get; }
+
+    protected ISecretEncryptor Encryptor { get; }
+
+    protected ILogger<DatabaseAuthorizationParameterStorageBase> Logger { get; }
+
+    public DatabaseAuthorizationParameterStorageBase(
+        IScopeProvider scopeProvider,
+        ISecretEncryptor encryptor,
+        ILogger<DatabaseAuthorizationParameterStorageBase> logger)
+    {
+        ScopeProvider = scopeProvider;
+        Encryptor = encryptor;
+        Logger = logger;
+    }
+}

--- a/src/Umbraco.AuthorizedServices/Services/Implement/DatabaseKeyStorage.cs
+++ b/src/Umbraco.AuthorizedServices/Services/Implement/DatabaseKeyStorage.cs
@@ -1,0 +1,88 @@
+using Microsoft.Extensions.Logging;
+using Umbraco.AuthorizedServices.Models;
+using Umbraco.AuthorizedServices.Persistence.Dtos;
+using Umbraco.Cms.Infrastructure.Scoping;
+
+namespace Umbraco.AuthorizedServices.Services.Implement;
+
+/// <summary>
+/// Implements <see cref="IKeyStorage"/> for API key storage using a database table.
+/// </summary>
+internal sealed class DatabaseKeyStorage : IKeyStorage
+{
+    private readonly IScopeProvider _scopeProvider;
+    private readonly ISecretEncryptor _encryptor;
+    private readonly ILogger<DatabaseKeyStorage> _logger;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DatabaseKeyStorage"/> class.
+    /// </summary>
+    public DatabaseKeyStorage(IScopeProvider scopeProvider, ISecretEncryptor encryptor, ILogger<DatabaseKeyStorage> logger)
+    {
+        _scopeProvider = scopeProvider;
+        _encryptor = encryptor;
+        _logger = logger;
+    }
+
+    /// <inheritdoc/>
+    public string? GetKey(string serviceAlias)
+    {
+        using IScope scope = _scopeProvider.CreateScope();
+
+        KeyDto entity = scope.Database.FirstOrDefault<KeyDto>("where serviceAlias = @0", serviceAlias);
+        if (entity == null)
+        {
+            return null;
+        }
+
+        if (!_encryptor.TryDecrypt(entity.ApiKey, out string apiKey))
+        {
+            RemoveCorruptApiKey(serviceAlias);
+            return null;
+        }
+
+        return apiKey;
+    }
+
+    /// <inheritdoc/>
+    public void SaveKey(string serviceAlias, string key)
+    {
+        using IScope scope = _scopeProvider.CreateScope();
+
+        KeyDto entity = scope.Database.SingleOrDefault<KeyDto>("where serviceAlias = @0", serviceAlias);
+
+        bool insert = entity == null;
+        entity ??= new KeyDto { ServiceAlias = serviceAlias };
+
+        entity.ApiKey = _encryptor.Encrypt(key);
+
+        if (insert)
+        {
+            scope.Database.Insert(entity);
+        }
+        else
+        {
+            scope.Database.Update(entity);
+        }
+
+        scope.Complete();
+    }
+
+    /// <inheritdoc/>
+    public void DeleteKey(string serviceAlias)
+    {
+        using IScope scope = _scopeProvider.CreateScope();
+
+        KeyDto entity = scope.Database.Single<KeyDto>("where serviceAlias = @0", serviceAlias);
+
+        scope.Database.Delete(entity);
+
+        scope.Complete();
+    }
+
+    private void RemoveCorruptApiKey(string serviceAlias)
+    {
+        DeleteKey(serviceAlias);
+        _logger.LogWarning($"Could not decrypt the stored API key for authorized service with alias '{serviceAlias}'. API key has been removed from storage.");
+    }
+}

--- a/src/Umbraco.AuthorizedServices/Services/Implement/DatabaseTokenStorage.cs
+++ b/src/Umbraco.AuthorizedServices/Services/Implement/DatabaseTokenStorage.cs
@@ -8,26 +8,20 @@ namespace Umbraco.AuthorizedServices.Services.Implement;
 /// <summary>
 /// Implements <see cref="ITokenStorage"/> for token storage using a database table.
 /// </summary>
-internal sealed class DatabaseTokenStorage : ITokenStorage
+internal sealed class DatabaseTokenStorage : DatabaseAuthorizationParameterStorageBase, ITokenStorage
 {
-    private readonly IScopeProvider _scopeProvider;
-    private readonly ISecretEncryptor _encryptor;
-    private readonly ILogger<DatabaseTokenStorage> _logger;
-
     /// <summary>
     /// Initializes a new instance of the <see cref="DatabaseTokenStorage"/> class.
     /// </summary>
     public DatabaseTokenStorage(IScopeProvider scopeProvider, ISecretEncryptor encryptor, ILogger<DatabaseTokenStorage> logger)
+        : base(scopeProvider, encryptor, logger)
     {
-        _scopeProvider = scopeProvider;
-        _encryptor = encryptor;
-        _logger = logger;
     }
 
     /// <inheritdoc/>
     public Token? GetToken(string serviceAlias)
     {
-        using IScope scope = _scopeProvider.CreateScope();
+        using IScope scope = ScopeProvider.CreateScope();
 
         TokenDto entity = scope.Database.FirstOrDefault<TokenDto>("where serviceAlias = @0", serviceAlias);
         if (entity == null)
@@ -35,7 +29,7 @@ internal sealed class DatabaseTokenStorage : ITokenStorage
             return null;
         }
 
-        if (!_encryptor.TryDecrypt(entity.AccessToken, out string accessToken))
+        if (!Encryptor.TryDecrypt(entity.AccessToken, out string accessToken))
         {
             RemoveCorruptToken(serviceAlias, "access");
             return null;
@@ -44,7 +38,7 @@ internal sealed class DatabaseTokenStorage : ITokenStorage
         var refreshToken = string.Empty;
         if (!string.IsNullOrEmpty(entity.RefreshToken))
         {
-            if (!_encryptor.TryDecrypt(entity.RefreshToken, out refreshToken))
+            if (!Encryptor.TryDecrypt(entity.RefreshToken, out refreshToken))
             {
                 RemoveCorruptToken(serviceAlias, "refresh");
                 return null;
@@ -57,22 +51,22 @@ internal sealed class DatabaseTokenStorage : ITokenStorage
     private void RemoveCorruptToken(string serviceAlias, string tokenType)
     {
         DeleteToken(serviceAlias);
-        _logger.LogWarning($"Could not decrypt the stored {tokenType} token for authorized service with alias '{serviceAlias}'. Token has been removed from storage.");
+        Logger.LogWarning($"Could not decrypt the stored {tokenType} token for authorized service with alias '{serviceAlias}'. Token has been removed from storage.");
     }
 
     /// <inheritdoc/>
     public void SaveToken(string serviceAlias, Token token)
     {
-        using IScope scope = _scopeProvider.CreateScope();
+        using IScope scope = ScopeProvider.CreateScope();
 
         TokenDto entity = scope.Database.SingleOrDefault<TokenDto>("where serviceAlias = @0", serviceAlias);
 
         bool insert = entity == null;
         entity ??= new TokenDto { ServiceAlias = serviceAlias };
 
-        entity.AccessToken = _encryptor.Encrypt(token.AccessToken);
+        entity.AccessToken = Encryptor.Encrypt(token.AccessToken);
         entity.RefreshToken = !string.IsNullOrEmpty(token.RefreshToken)
-            ? _encryptor.Encrypt(token.RefreshToken)
+            ? Encryptor.Encrypt(token.RefreshToken)
             : string.Empty;
         entity.ExpiresOn = token.ExpiresOn;
 
@@ -91,7 +85,7 @@ internal sealed class DatabaseTokenStorage : ITokenStorage
     /// <inheritdoc/>
     public void DeleteToken(string serviceAlias)
     {
-        using IScope scope = _scopeProvider.CreateScope();
+        using IScope scope = ScopeProvider.CreateScope();
 
         TokenDto entity = scope.Database.Single<TokenDto>("where serviceAlias = @0", serviceAlias);
 

--- a/src/Umbraco.AuthorizedServices/appsettings-schema.Umbraco.AuthorizedServices.json
+++ b/src/Umbraco.AuthorizedServices/appsettings-schema.Umbraco.AuthorizedServices.json
@@ -72,7 +72,11 @@
         },
         "CanManuallyProvideToken": {
           "type": "boolean",
-          "description": "Get or sets a value indicating whether editor can manually add token."
+          "description": "Get or sets a value indicating whether an administrator can manually add token."
+        },
+        "CanManuallyProvideApiKey": {
+          "type": "boolean",
+          "description": "Get or sets a value indicating whether an administrator can manually add API key."
         },
         "AuthorizationUrlRequiresRedirectUrl": {
           "type": "boolean",

--- a/tests/Umbraco.AuthorizedServices.Tests/Services/AuthorizedRequestBuilderTests.cs
+++ b/tests/Umbraco.AuthorizedServices.Tests/Services/AuthorizedRequestBuilderTests.cs
@@ -56,7 +56,7 @@ internal class AuthorizedRequestBuilderTests : AuthorizedServiceTestsBase
         AuthorizedRequestBuilder sut = CreateSut();
 
         // Act
-        HttpRequestMessage result = sut.CreateRequestMessageWithApiKey(serviceDetail, Path, HttpMethod.Post, data);
+        HttpRequestMessage result = sut.CreateRequestMessageWithApiKey(serviceDetail, Path, HttpMethod.Post, "abc", data);
 
         // Assert
         var expectedUri = new Uri("https://service.url/api/test?x-api-key=abc");
@@ -86,7 +86,7 @@ internal class AuthorizedRequestBuilderTests : AuthorizedServiceTestsBase
         AuthorizedRequestBuilder sut = CreateSut();
 
         // Act
-        HttpRequestMessage result = sut.CreateRequestMessageWithApiKey(serviceDetail, Path, HttpMethod.Post, data);
+        HttpRequestMessage result = sut.CreateRequestMessageWithApiKey(serviceDetail, Path, HttpMethod.Post, "abc", data);
 
         // Assert
         var expectedUri = new Uri("https://service.url/api/test");

--- a/tests/Umbraco.AuthorizedServices.Tests/Services/AuthorizedServiceAuthorizerTests.cs
+++ b/tests/Umbraco.AuthorizedServices.Tests/Services/AuthorizedServiceAuthorizerTests.cs
@@ -15,6 +15,7 @@ internal class AuthorizedServiceAuthorizerTests : AuthorizedServiceTestsBase
     public void SetUp()
     {
         TokenStorageMock = new Mock<ITokenStorage>();
+        KeyStorageMock = new Mock<IKeyStorage>();
     }
 
     [Test]

--- a/tests/Umbraco.AuthorizedServices.Tests/Services/AuthorizedServiceAuthorizerTests.cs
+++ b/tests/Umbraco.AuthorizedServices.Tests/Services/AuthorizedServiceAuthorizerTests.cs
@@ -69,6 +69,7 @@ internal class AuthorizedServiceAuthorizerTests : AuthorizedServiceTestsBase
             AppCaches.Disabled,
             new TokenFactory(new DateTimeProvider()),
             TokenStorageMock.Object,
+            KeyStorageMock.Object,
             authorizationRequestSenderMock.Object,
             new NullLogger<AuthorizedServiceAuthorizer>(),
             optionsMonitorServiceDetailMock.Object,

--- a/tests/Umbraco.AuthorizedServices.Tests/Services/AuthorizedServiceCallerTests.cs
+++ b/tests/Umbraco.AuthorizedServices.Tests/Services/AuthorizedServiceCallerTests.cs
@@ -18,6 +18,7 @@ internal class AuthorizedServiceCallerTests : AuthorizedServiceTestsBase
     public void SetUp()
     {
         TokenStorageMock = new Mock<ITokenStorage>();
+        KeyStorageMock = new Mock<IKeyStorage>();
     }
 
     [Test]
@@ -38,6 +39,23 @@ internal class AuthorizedServiceCallerTests : AuthorizedServiceTestsBase
 
         TokenStorageMock
             .Verify(x => x.SaveToken(It.IsAny<string>(), It.IsAny<Token>()), Times.Never);
+    }
+
+    [Test]
+    public async Task SendRequestAsync_WithoutData_WithApiKeyFromStorage_WithSuccessReponse_ReturnsExpectedResponse()
+    {
+        // Arrange
+        StoreApiKey();
+
+        var path = "/api/test/";
+        AuthorizedServiceCaller sut = CreateService(HttpStatusCode.OK, authenticationMethod: AuthenticationMethod.ApiKey);
+
+        // Act
+        TestResponseData? result = await sut.SendRequestAsync<TestResponseData>(ServiceAlias, path, HttpMethod.Get);
+
+        // Assert
+        KeyStorageMock
+            .Verify(x => x.SaveKey(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
     }
 
     [Test]
@@ -151,7 +169,7 @@ internal class AuthorizedServiceCallerTests : AuthorizedServiceTestsBase
     public void GetApiKey_WithExistingApiKey_ReturnsApiKey()
     {
         // Arrange
-        AuthorizedServiceCaller sut = CreateService(includeApiKey: true);
+        AuthorizedServiceCaller sut = CreateService(authenticationMethod: AuthenticationMethod.ApiKey);
 
         // Act
         var result = sut.GetApiKey(ServiceAlias);
@@ -159,6 +177,21 @@ internal class AuthorizedServiceCallerTests : AuthorizedServiceTestsBase
         // Assert
         result.Should().NotBeNull();
         result!.Should().Be("test-api-key");
+    }
+
+    [Test]
+    public void GetApiKey_WithStoredApiKey_ReturnsStoredApiKey()
+    {
+        // Arrange
+        StoreApiKey();
+        AuthorizedServiceCaller sut = CreateService(authenticationMethod: AuthenticationMethod.ApiKey);
+
+        // Act
+        var result = sut.GetApiKey(ServiceAlias);
+
+        // Assert
+        result.Should().NotBeNull();
+        result!.Should().Be("stored-test-api-key");
     }
 
     [Test]
@@ -207,11 +240,17 @@ internal class AuthorizedServiceCallerTests : AuthorizedServiceTestsBase
             .Setup(x => x.GetToken(It.Is<string>(y => y == ServiceAlias)))
             .Returns(new Token("abc", "def", DateTime.Now.AddDays(daysUntilExpiry)));
 
+    private void StoreApiKey() =>
+        KeyStorageMock
+            .Setup(x => x.GetKey(It.Is<string>(y => y == ServiceAlias)))
+            .Returns("stored-test-api-key");
+
+
     private AuthorizedServiceCaller CreateService(
         HttpStatusCode statusCode = HttpStatusCode.OK,
         string? responseContent = null,
         HttpStatusCode refreshTokenStatusCode = HttpStatusCode.OK,
-        bool includeApiKey = false)
+        AuthenticationMethod authenticationMethod = AuthenticationMethod.OAuth2AuthorizationCode)
     {
         var authorizationRequestSenderMock = new Mock<IAuthorizationRequestSender>();
 
@@ -225,7 +264,7 @@ internal class AuthorizedServiceCallerTests : AuthorizedServiceTestsBase
             .Setup(x => x.SendRequest(It.Is<ServiceDetail>(y => y.Alias == ServiceAlias), It.Is<Dictionary<string, string>>(y => y["grant_type"] == "refresh_token")))
             .ReturnsAsync(httpResponseMessage);
 
-        Mock<IOptionsMonitor<ServiceDetail>> optionsMonitorServiceDetailMock = CreateOptionsMonitorServiceDetail(includeApiKey);
+        Mock<IOptionsMonitor<ServiceDetail>> optionsMonitorServiceDetailMock = CreateOptionsMonitorServiceDetail(authenticationMethod);
         var factory = new JsonSerializerFactory(optionsMonitorServiceDetailMock.Object, new JsonNetSerializer());
 
         return new AuthorizedServiceCaller(

--- a/tests/Umbraco.AuthorizedServices.Tests/Services/AuthorizedServiceCallerTests.cs
+++ b/tests/Umbraco.AuthorizedServices.Tests/Services/AuthorizedServiceCallerTests.cs
@@ -22,7 +22,7 @@ internal class AuthorizedServiceCallerTests : AuthorizedServiceTestsBase
     }
 
     [Test]
-    public async Task SendRequestAsync_WithoutData_WithValidAccessToken_WithSuccessReponse_ReturnsExpectedResponse()
+    public async Task SendRequestAsync_WithoutData_WithValidAccessToken_WithSuccessResponse_ReturnsExpectedResponse()
     {
         // Arrange
         StoreToken();
@@ -42,7 +42,7 @@ internal class AuthorizedServiceCallerTests : AuthorizedServiceTestsBase
     }
 
     [Test]
-    public async Task SendRequestAsync_WithoutData_WithApiKeyFromStorage_WithSuccessReponse_ReturnsExpectedResponse()
+    public async Task SendRequestAsync_WithoutData_WithApiKeyFromStorage_WithSuccessResponse_ReturnsExpectedResponse()
     {
         // Arrange
         StoreApiKey();
@@ -59,7 +59,7 @@ internal class AuthorizedServiceCallerTests : AuthorizedServiceTestsBase
     }
 
     [Test]
-    public async Task SendRequestAsync_WithoutData_WithValidAccessToken_WithFaileReponse_ThrowsExpectedException()
+    public async Task SendRequestAsync_WithoutData_WithValidAccessToken_WithFailedResponse_ThrowsExpectedException()
     {
         // Arrange
         StoreToken();
@@ -75,7 +75,7 @@ internal class AuthorizedServiceCallerTests : AuthorizedServiceTestsBase
     }
 
     [Test]
-    public async Task SendRequestRawAsync_WithoutData_WithValidAccessToken_WithSuccessReponse_ReturnsExpectedResponse()
+    public async Task SendRequestRawAsync_WithoutData_WithValidAccessToken_WithSuccessResponse_ReturnsExpectedResponse()
     {
         // Arrange
         StoreToken();
@@ -169,7 +169,7 @@ internal class AuthorizedServiceCallerTests : AuthorizedServiceTestsBase
     public void GetApiKey_WithExistingApiKey_ReturnsApiKey()
     {
         // Arrange
-        AuthorizedServiceCaller sut = CreateService(authenticationMethod: AuthenticationMethod.ApiKey);
+        AuthorizedServiceCaller sut = CreateService(authenticationMethod: AuthenticationMethod.ApiKey, withConfiguredApiKey: true);
 
         // Act
         var result = sut.GetApiKey(ServiceAlias);
@@ -184,7 +184,7 @@ internal class AuthorizedServiceCallerTests : AuthorizedServiceTestsBase
     {
         // Arrange
         StoreApiKey();
-        AuthorizedServiceCaller sut = CreateService(authenticationMethod: AuthenticationMethod.ApiKey);
+        AuthorizedServiceCaller sut = CreateService(authenticationMethod: AuthenticationMethod.ApiKey, withConfiguredApiKey: false);
 
         // Act
         var result = sut.GetApiKey(ServiceAlias);
@@ -250,7 +250,8 @@ internal class AuthorizedServiceCallerTests : AuthorizedServiceTestsBase
         HttpStatusCode statusCode = HttpStatusCode.OK,
         string? responseContent = null,
         HttpStatusCode refreshTokenStatusCode = HttpStatusCode.OK,
-        AuthenticationMethod authenticationMethod = AuthenticationMethod.OAuth2AuthorizationCode)
+        AuthenticationMethod authenticationMethod = AuthenticationMethod.OAuth2AuthorizationCode,
+        bool withConfiguredApiKey = false)
     {
         var authorizationRequestSenderMock = new Mock<IAuthorizationRequestSender>();
 
@@ -264,7 +265,7 @@ internal class AuthorizedServiceCallerTests : AuthorizedServiceTestsBase
             .Setup(x => x.SendRequest(It.Is<ServiceDetail>(y => y.Alias == ServiceAlias), It.Is<Dictionary<string, string>>(y => y["grant_type"] == "refresh_token")))
             .ReturnsAsync(httpResponseMessage);
 
-        Mock<IOptionsMonitor<ServiceDetail>> optionsMonitorServiceDetailMock = CreateOptionsMonitorServiceDetail(authenticationMethod);
+        Mock<IOptionsMonitor<ServiceDetail>> optionsMonitorServiceDetailMock = CreateOptionsMonitorServiceDetail(authenticationMethod, withConfiguredApiKey);
         var factory = new JsonSerializerFactory(optionsMonitorServiceDetailMock.Object, new JsonNetSerializer());
 
         return new AuthorizedServiceCaller(

--- a/tests/Umbraco.AuthorizedServices.Tests/Services/AuthorizedServiceCallerTests.cs
+++ b/tests/Umbraco.AuthorizedServices.Tests/Services/AuthorizedServiceCallerTests.cs
@@ -232,6 +232,7 @@ internal class AuthorizedServiceCallerTests : AuthorizedServiceTestsBase
             AppCaches.Disabled,
             new TokenFactory(new DateTimeProvider()),
             TokenStorageMock.Object,
+            KeyStorageMock.Object,
             authorizationRequestSenderMock.Object,
             new NullLogger<AuthorizedServiceCaller>(),
             optionsMonitorServiceDetailMock.Object,

--- a/tests/Umbraco.AuthorizedServices.Tests/Services/AuthorizedServiceTestsBase.cs
+++ b/tests/Umbraco.AuthorizedServices.Tests/Services/AuthorizedServiceTestsBase.cs
@@ -10,6 +10,8 @@ internal abstract class AuthorizedServiceTestsBase
 
     protected Mock<ITokenStorage> TokenStorageMock { get; set; } = null!;
 
+    protected Mock<IKeyStorage> KeyStorageMock { get; set; } = null!;
+
     protected static Mock<IOptionsMonitor<ServiceDetail>> CreateOptionsMonitorServiceDetail(bool includeApiKey = false)
     {
         var optionsMonitorServiceDetailMock = new Mock<IOptionsMonitor<ServiceDetail>>();

--- a/tests/Umbraco.AuthorizedServices.Tests/Services/AuthorizedServiceTestsBase.cs
+++ b/tests/Umbraco.AuthorizedServices.Tests/Services/AuthorizedServiceTestsBase.cs
@@ -13,7 +13,8 @@ internal abstract class AuthorizedServiceTestsBase
     protected Mock<IKeyStorage> KeyStorageMock { get; set; } = null!;
 
     protected static Mock<IOptionsMonitor<ServiceDetail>> CreateOptionsMonitorServiceDetail(
-        AuthenticationMethod authenticationMethod = AuthenticationMethod.OAuth2AuthorizationCode)
+        AuthenticationMethod authenticationMethod = AuthenticationMethod.OAuth2AuthorizationCode,
+        bool withConfiguredApiKey = false)
     {
         var optionsMonitorServiceDetailMock = new Mock<IOptionsMonitor<ServiceDetail>>();
         optionsMonitorServiceDetailMock.Setup(o => o.Get(ServiceAlias)).Returns(new ServiceDetail()
@@ -22,7 +23,7 @@ internal abstract class AuthorizedServiceTestsBase
             ApiHost = "https://service.url",
             AuthenticationMethod = authenticationMethod,
             JsonSerializer = JsonSerializerOption.JsonNet,
-            ApiKey = authenticationMethod == AuthenticationMethod.ApiKey ? "test-api-key" : string.Empty,
+            ApiKey = authenticationMethod == AuthenticationMethod.ApiKey && withConfiguredApiKey ? "test-api-key" : string.Empty,
             ApiKeyProvision = authenticationMethod == AuthenticationMethod.ApiKey
                 ? new ApiKeyProvision { Method = ApiKeyProvisionMethod.QueryString, Key = "key"} : null
         });

--- a/tests/Umbraco.AuthorizedServices.Tests/Services/AuthorizedServiceTestsBase.cs
+++ b/tests/Umbraco.AuthorizedServices.Tests/Services/AuthorizedServiceTestsBase.cs
@@ -8,9 +8,9 @@ internal abstract class AuthorizedServiceTestsBase
 {
     protected const string ServiceAlias = "testService";
 
-    protected static Mock<ITokenStorage> TokenStorageMock { get; set; } = null!;
+    protected Mock<ITokenStorage> TokenStorageMock { get; set; } = null!;
 
-    protected static Mock<IKeyStorage> KeyStorageMock { get; set; } = null!;
+    protected Mock<IKeyStorage> KeyStorageMock { get; set; } = null!;
 
     protected static Mock<IOptionsMonitor<ServiceDetail>> CreateOptionsMonitorServiceDetail(
         AuthenticationMethod authenticationMethod = AuthenticationMethod.OAuth2AuthorizationCode)

--- a/tests/Umbraco.AuthorizedServices.Tests/Services/AuthorizedServiceTestsBase.cs
+++ b/tests/Umbraco.AuthorizedServices.Tests/Services/AuthorizedServiceTestsBase.cs
@@ -8,19 +8,23 @@ internal abstract class AuthorizedServiceTestsBase
 {
     protected const string ServiceAlias = "testService";
 
-    protected Mock<ITokenStorage> TokenStorageMock { get; set; } = null!;
+    protected static Mock<ITokenStorage> TokenStorageMock { get; set; } = null!;
 
-    protected Mock<IKeyStorage> KeyStorageMock { get; set; } = null!;
+    protected static Mock<IKeyStorage> KeyStorageMock { get; set; } = null!;
 
-    protected static Mock<IOptionsMonitor<ServiceDetail>> CreateOptionsMonitorServiceDetail(bool includeApiKey = false)
+    protected static Mock<IOptionsMonitor<ServiceDetail>> CreateOptionsMonitorServiceDetail(
+        AuthenticationMethod authenticationMethod = AuthenticationMethod.OAuth2AuthorizationCode)
     {
         var optionsMonitorServiceDetailMock = new Mock<IOptionsMonitor<ServiceDetail>>();
         optionsMonitorServiceDetailMock.Setup(o => o.Get(ServiceAlias)).Returns(new ServiceDetail()
         {
             Alias = ServiceAlias,
             ApiHost = "https://service.url",
+            AuthenticationMethod = authenticationMethod,
             JsonSerializer = JsonSerializerOption.JsonNet,
-            ApiKey = includeApiKey ? "test-api-key" : string.Empty
+            ApiKey = authenticationMethod == AuthenticationMethod.ApiKey ? "test-api-key" : string.Empty,
+            ApiKeyProvision = authenticationMethod == AuthenticationMethod.ApiKey
+                ? new ApiKeyProvision { Method = ApiKeyProvisionMethod.QueryString, Key = "key"} : null
         });
 
         return optionsMonitorServiceDetailMock;


### PR DESCRIPTION
Current PR contains the implementation of a feature allowing administrators to persist an API key in the database.
With this update, as a service could have a key both in the settings and in the database, across various checks the stored token takes precedence.

Updates:
- `CanManuallyProvideApiKey` property for service detail, to toggle visibility of the _Add API key_ section in the backoffice.
- Storage implementation using `IKeyStorage`.
- Migration
- Methods for persisting the API key.
- Unit tests