### PR TITLE
Adds Meetup.com to example site

### DIFF
--- a/examples/Umbraco.AuthorizedServices.TestSite/Controllers/TestAuthorizedServicesController.cs
+++ b/examples/Umbraco.AuthorizedServices.TestSite/Controllers/TestAuthorizedServicesController.cs
@@ -12,6 +12,22 @@ public class TestAuthorizedServicesController : UmbracoApiController
 
     public TestAuthorizedServicesController(IAuthorizedServiceCaller authorizedServiceCaller) => _authorizedServiceCaller = authorizedServiceCaller;
 
+    // /umbraco/api/TestAuthorizedServices/GetMeetupSelfUserInfo
+    public async Task<IActionResult> GetMeetupSelfUserInfo()
+    {
+        // This makes a GraphQL query
+        var response = await _authorizedServiceCaller.SendRequestRawAsync(
+            "meetup",
+            "/gql",
+            HttpMethod.Post,
+            new MeetupRequest
+            {
+                Query = "query { self { id name bio city } }"
+            });
+
+        return Content(response);
+    }
+
     public async Task<IActionResult> GetUmbracoContributorsFromGitHub()
     {
         List<GitHubContributorResponse>? response = await _authorizedServiceCaller.GetRequestAsync<List<GitHubContributorResponse>>(

--- a/examples/Umbraco.AuthorizedServices.TestSite/Models/ServiceResponses/MeetupRequest.cs
+++ b/examples/Umbraco.AuthorizedServices.TestSite/Models/ServiceResponses/MeetupRequest.cs
@@ -1,0 +1,10 @@
+﻿using Newtonsoft.Json;
+
+namespace Umbraco.AuthorizedServices.TestSite.Models.ServiceResponses
+{
+    public class MeetupRequest
+    {
+        [JsonProperty("query")]
+        public string Query { get; set; } = string.Empty;
+    }
+}

--- a/examples/Umbraco.AuthorizedServices.TestSite/appsettings.json
+++ b/examples/Umbraco.AuthorizedServices.TestSite/appsettings.json
@@ -496,6 +496,19 @@
             "ExchangeTokenWhenExpiresWithin": "25.00:00:00"
           },
           "RefreshAccessTokenWhenExpiresWithin": "00.00:00:40"
+        },
+        "meetup": {
+          "DisplayName": "Meetup",
+          "ApiHost": "https://api.meetup.com",
+          "IdentityHost": "https://secure.meetup.com",
+          "TokenHost": "https://secure.meetup.com",
+          "RequestIdentityPath": "/oauth2/authorize",
+          "AuthorizationUrlRequiresRedirectUrl": true,
+          "RequestTokenPath": "/oauth2/access",
+          "RequestTokenFormat": "FormUrlEncoded",
+          "ClientId": "",
+          "ClientSecret": "",
+          "SampleRequest": "/gql"
         }
       }
     }


### PR DESCRIPTION
This adds a sample config of Meetup.com to the example site

This is a GraphQL based API that uses an oAuth flow
https://www.meetup.com/api/authentication/#p01-using-oauth2-section

You can create a Meetup.com oAuth client here
https://www.meetup.com/api/oauth/create/

Then you can use it with GraphQL requests
https://www.meetup.com/api/guide/#graphQl-guide


## Example response
When visiting `/umbraco/api/TestAuthorizedServices/GetMeetupSelfUserInfo` you get the GraphQL result back of the following GraphQl query

```graphql
query { 
    self { 
        id 
        name 
        bio 
        city 
    }
}
```

![image](https://github.com/umbraco/Umbraco.AuthorizedServices/assets/1389894/45194ab5-f55e-4f64-ae4d-d83b34b6816d)

