### PR TITLE
Add test services endpoints

### DIFF
--- a/examples/Umbraco.AuthorizedServices.TestSite/Controllers/TestAuthorizedServicesController.cs
+++ b/examples/Umbraco.AuthorizedServices.TestSite/Controllers/TestAuthorizedServicesController.cs
@@ -138,16 +138,62 @@ public class TestAuthorizedServicesController : AuthorizedServicesApiControllerB
         return Content(string.Join(", ", response.Select(x => x.ToString())));
     }
 
-    public async Task<IActionResult> GetVideoDetailsFromYouTube()
+    public async Task<IActionResult> GetVideoDetailsFromYouTube(string videoId)
     {
         Attempt<string?> responseAttempt = await AuthorizedServiceCaller.SendRequestRawAsync(
             "youtube",
-            "/v3/videos?id=[video_id]&part=snippet,contentDetails,statistics,status",
+            $"/v3/videos?id={videoId}&part=snippet,contentDetails,statistics,status",
             HttpMethod.Get);
 
         if (!responseAttempt.Success || responseAttempt.Result is null)
         {
             return HandleFailedRequest(responseAttempt.Exception, "Could not retrieve video details.");
+        }
+
+        var response = responseAttempt.Result;
+        return Content(response);
+    }
+
+    public async Task<IActionResult> GetInstagramProfile()
+    {
+        Attempt<InstagramProfileResponse?> responseAttempt = await AuthorizedServiceCaller.GetRequestAsync<InstagramProfileResponse>(
+            "instagram",
+            $"/v3.0/me?fields=username");
+
+        if (!responseAttempt.Success || responseAttempt.Result is null)
+        {
+            return HandleFailedRequest(responseAttempt.Exception, "Could not retrieve account details.");
+        }
+
+        return Content(responseAttempt.Result.Username);
+    }
+
+    public async Task<IActionResult> GetTwitterProfileUsingOAuth1()
+    {
+        Attempt<string?> responseAttempt = await AuthorizedServiceCaller.SendRequestRawAsync(
+            "twitter",
+            "/1.1/account/settings.json",
+            HttpMethod.Get);
+
+        if (!responseAttempt.Success || responseAttempt.Result is null)
+        {
+            return HandleFailedRequest(responseAttempt.Exception, "Could not retrieve account details.");
+        }
+
+        var response = responseAttempt.Result;
+        return Content(response);
+    }
+
+    public async Task<IActionResult> GetTwitterProfileUsingOAuth2()
+    {
+        Attempt<string?> responseAttempt = await AuthorizedServiceCaller.SendRequestRawAsync(
+            "twitter_oauth2",
+            "/2/users/me",
+            HttpMethod.Get);
+
+        if (!responseAttempt.Success || responseAttempt.Result is null)
+        {
+            return HandleFailedRequest(responseAttempt.Exception, "Could not retrieve account details.");
         }
 
         var response = responseAttempt.Result;

--- a/examples/Umbraco.AuthorizedServices.TestSite/appsettings.json
+++ b/examples/Umbraco.AuthorizedServices.TestSite/appsettings.json
@@ -154,9 +154,8 @@
           "Scopes": "r_emailaddress r_liteprofile w_member_social",
           "SampleRequest": "/v2/me"
         },
-        "twitter-oauth2": {
+        "twitter_oauth2": {
           "DisplayName": "Twitter OAuth2",
-          "AuthenticationMethod": "OAuth2Code",
           "ApiHost": "https://api.twitter.com",
           "IdentityHost": "https://twitter.com",
           "TokenHost": "https://api.twitter.com",
@@ -508,7 +507,7 @@
         },
         "instagram": {
           "DisplayName": "Instagram",
-          "ApiHost": "https://api.instagram.com",
+          "ApiHost": "https://graph.instagram.com",
           "IdentityHost": "https://api.instagram.com",
           "TokenHost": "https://api.instagram.com",
           "RequestIdentityPath": "/oauth/authorize",

--- a/src/Umbraco.AuthorizedServices/ClientApp/src/backoffice/AuthorizedServices/edit.controller.ts
+++ b/src/Umbraco.AuthorizedServices/ClientApp/src/backoffice/AuthorizedServices/edit.controller.ts
@@ -37,7 +37,7 @@ function AuthorizedServiceEditController(this: any, $routeParams, $location, aut
           notificationsService.success("Authorized Services", "The '" + vm.displayName + "' service has been authorized.");
           loadServiceDetails(serviceAlias);
         });
-    } if (vm.authenticationMethod.isOAuth1) {
+    } else if (vm.authenticationMethod.isOAuth1) {
       authorizedServiceResource.generateOAuth1RequestToken(serviceAlias)
         .then(function (response) {
           location.href = response.data.message;

--- a/src/Umbraco.AuthorizedServices/ClientApp/src/backoffice/AuthorizedServices/edit.html
+++ b/src/Umbraco.AuthorizedServices/ClientApp/src/backoffice/AuthorizedServices/edit.html
@@ -36,7 +36,7 @@
                   </div>
                 </div>
               </div>
-              <div ng-show="!vm.isAuthorized">
+              <div ng-show="!vm.isAuthorized && !vm.authenticationMethod.isApiKey">
                 <p>To authorize the service click to sign-in to the provider's portal, confirm the permission request and return to Umbraco.</p>
                 <umb-button action="vm.authorizeAccess()"
                             type="button"


### PR DESCRIPTION
Following test cases of the four authentication methods we have for services, I've added some small changes as follows (no other issues encountered during testing):
- added additional test endpoints for _Instagram_ and _Twitter_, and amended the one for _YouTube_.
- small fix to hide the _Authorize Service_ button in the service details view if the authentication method is `ApiKey`.
- renamed `twitter` service to use `_` instead of a dash, as it impacted the validation of the state on authorization callback.