### PR TITLE
Added the option of providing additional parameters in the header when making requests using API key authorization.

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,9 @@ Details of services available need to be applied to the Umbraco web application'
             "ApiKey": "",
             "ApiKeyProvision": {
               "Method": "HttpHeader|QueryString",
-              "Key": ""
+              "Key": "",
+              "AdditionalParameters": {
+              }
             },
             "ClientId": "",
             "ClientSecret": "",
@@ -169,7 +171,7 @@ Used, along with `IdentityHost` to construct a URL that the user is redirected t
 
 ###### CanManuallyProvideToken
 
-Specifies whether the service supports generating of tokens via the provider's developer portal such that an administrator can manually add one via the backoffice. 
+Specifies whether the service supports generating of tokens via the provider's developer portal such that an administrator can manually add one via the backoffice.
 
 ###### CanManuallyProvideApiKey
 
@@ -181,7 +183,7 @@ Specifies whether the access token can be exchanged with a long lived one.
 
 ###### ExchangeTokenProvision
 
-Provides a strongly typed configuration for a setup that allows exchanging an access token. 
+Provides a strongly typed configuration for a setup that allows exchanging an access token.
 
 This setting is only utilized when `CanExchangeToken` is set to `true`.
 
@@ -192,7 +194,7 @@ The configuration of exchange tokens includes:
 - `TokenGrantType`
 - `RequestRefreshTokenPath`
 - `RefreshTokenGrantType`
-- `ExchangeTokenWhenExpiresWithin` 
+- `ExchangeTokenWhenExpiresWithin`
 
 ###### AuthorizationUrlRequiresRedirectUrl
 
@@ -230,6 +232,8 @@ Specifies the key a service with `AuthenticationMethod` set to `ApiKey` will use
 ###### ApiKeyProvision
 
 For `ApiKey` authentication methods, options for passing the API key need to be set, by specifying a method: `HttpHeader` or `QueryString` and the name for the key holding the value.
+
+You can also provide additional parameters that will be included in the querystring or headers via the `AdditionalParameters` dictionary.
 
 ###### ClientId *
 

--- a/examples/Umbraco.AuthorizedServices.TestSite/Models/ServiceResponses/InstagramProfileResponse.cs
+++ b/examples/Umbraco.AuthorizedServices.TestSite/Models/ServiceResponses/InstagramProfileResponse.cs
@@ -1,0 +1,12 @@
+using System.Text.Json.Serialization;
+
+namespace Umbraco.AuthorizedServices.TestSite.Models.ServiceResponses;
+
+public class InstagramProfileResponse
+{
+    [JsonPropertyName("id")]
+    public string Id { get; set; } = string.Empty;
+
+    [JsonPropertyName("username")]
+    public string Username { get; set; } = string.Empty;
+}

--- a/src/Umbraco.AuthorizedServices/Configuration/AuthorizedServiceSettings.cs
+++ b/src/Umbraco.AuthorizedServices/Configuration/AuthorizedServiceSettings.cs
@@ -80,6 +80,8 @@ public class ApiKeyProvision
 
     public string Key { get; set; } = string.Empty;
 
+    public IDictionary<string, string> AdditionalParameters { get; set; } = new Dictionary<string, string>();
+
     public override string ToString() => $"{Method} / {Key}";
 }
 

--- a/src/Umbraco.AuthorizedServices/Services/Implement/AuthorizedRequestBuilder.cs
+++ b/src/Umbraco.AuthorizedServices/Services/Implement/AuthorizedRequestBuilder.cs
@@ -76,20 +76,17 @@ internal sealed class AuthorizedRequestBuilder : IAuthorizedRequestBuilder
             return requestUri;
         }
 
-        if (apiKeyProvision.Method == ApiKeyProvisionMethod.QueryString)
+        bool pathHasQuerystring = HttpUtility.ParseQueryString(requestUri.Query).Count > 0;
+        var requestUrlWithQuerystring = new StringBuilder(requestUri.ToString());
+        requestUrlWithQuerystring.Append(pathHasQuerystring ? "&" : "?");
+        requestUrlWithQuerystring.AppendFormat("{0}={1}", apiKeyProvision.Key, apiKey);
+
+        foreach (KeyValuePair<string, string> additionalParameter in apiKeyProvision.AdditionalParameters)
         {
-            bool pathHasQuerystring = HttpUtility.ParseQueryString(requestUri.Query).Count > 0;
-            var requestUrlWithQuerystring = new StringBuilder(requestUri.ToString());
-            requestUrlWithQuerystring.Append(pathHasQuerystring ? "&" : "?");
-            requestUrlWithQuerystring.AppendFormat("{0}={1}", apiKeyProvision.Key, apiKey);
-
-            foreach (KeyValuePair<string, string> additionalParameter in apiKeyProvision.AdditionalParameters)
-            {
-                requestUrlWithQuerystring.AppendFormat("&{0}={1}", additionalParameter.Key, additionalParameter.Value);
-            }
-
-            requestUri = new Uri(requestUrlWithQuerystring.ToString());
+            requestUrlWithQuerystring.AppendFormat("&{0}={1}", additionalParameter.Key, additionalParameter.Value);
         }
+
+        requestUri = new Uri(requestUrlWithQuerystring.ToString());
 
         return requestUri;
     }

--- a/src/Umbraco.AuthorizedServices/Services/Implement/AuthorizedRequestBuilder.cs
+++ b/src/Umbraco.AuthorizedServices/Services/Implement/AuthorizedRequestBuilder.cs
@@ -52,12 +52,7 @@ internal sealed class AuthorizedRequestBuilder : IAuthorizedRequestBuilder
             throw new InvalidOperationException("Cannot create an HTTP request message for an API key request as no API key provision detail has been provided in configuration.");
         }
 
-        var requestUri = new Uri(serviceDetail.ApiHost + path);
-        if (serviceDetail.ApiKeyProvision.Method == ApiKeyProvisionMethod.QueryString)
-        {
-            NameValueCollection queryStringParams = HttpUtility.ParseQueryString(requestUri.Query);
-            requestUri = new Uri($"{requestUri}{(queryStringParams.Count > 0 ? "&" : "?")}{serviceDetail.ApiKeyProvision.Key}={apiKey}");
-        }
+        Uri requestUri = BuildRequestUriWithApiKey(serviceDetail.ApiHost, serviceDetail.ApiKeyProvision, path, apiKey);
 
         HttpRequestMessage requestMessage = CreateRequestMessage(
             httpMethod,
@@ -66,11 +61,47 @@ internal sealed class AuthorizedRequestBuilder : IAuthorizedRequestBuilder
 
         if (serviceDetail.ApiKeyProvision.Method == ApiKeyProvisionMethod.HttpHeader)
         {
-            requestMessage.Headers.Add(serviceDetail.ApiKeyProvision.Key, apiKey);
+            AddHeadersForRequestWithApiKeyProvisionedInHeader(requestMessage, serviceDetail.ApiKeyProvision, apiKey);
         }
 
         AddCommonHeaders(requestMessage);
         return requestMessage;
+    }
+
+    private static Uri BuildRequestUriWithApiKey(string apiHost, ApiKeyProvision apiKeyProvision, string path, string apiKey)
+    {
+        var requestUri = new Uri(apiHost + path);
+        if (apiKeyProvision.Method != ApiKeyProvisionMethod.QueryString)
+        {
+            return requestUri;
+        }
+
+        if (apiKeyProvision.Method == ApiKeyProvisionMethod.QueryString)
+        {
+            bool pathHasQuerystring = HttpUtility.ParseQueryString(requestUri.Query).Count > 0;
+            var requestUrlWithQuerystring = new StringBuilder(requestUri.ToString());
+            requestUrlWithQuerystring.Append(pathHasQuerystring ? "&" : "?");
+            requestUrlWithQuerystring.AppendFormat("{0}={1}", apiKeyProvision.Key, apiKey);
+
+            foreach (KeyValuePair<string, string> additionalParameter in apiKeyProvision.AdditionalParameters)
+            {
+                requestUrlWithQuerystring.AppendFormat("&{0}={1}", additionalParameter.Key, additionalParameter.Value);
+            }
+
+            requestUri = new Uri(requestUrlWithQuerystring.ToString());
+        }
+
+        return requestUri;
+    }
+
+    private static void AddHeadersForRequestWithApiKeyProvisionedInHeader(HttpRequestMessage requestMessage, ApiKeyProvision apiKeyProvision, string apiKey)
+    {
+        requestMessage.Headers.Add(apiKeyProvision.Key, apiKey);
+
+        foreach (KeyValuePair<string, string> additionalParameter in apiKeyProvision.AdditionalParameters)
+        {
+            requestMessage.Headers.Add(additionalParameter.Key, additionalParameter.Value);
+        }
     }
 
     public HttpRequestMessage CreateRequestMessageWithOAuth1Token<TRequest>(ServiceDetail serviceDetail, string path, HttpMethod httpMethod, OAuth1Token oauth1Token, TRequest? requestContent) where TRequest : class

--- a/tests/Umbraco.AuthorizedServices.Tests/Services/AuthorizedRequestBuilderTests.cs
+++ b/tests/Umbraco.AuthorizedServices.Tests/Services/AuthorizedRequestBuilderTests.cs
@@ -37,7 +37,7 @@ internal class AuthorizedRequestBuilderTests : AuthorizedServiceTestsBase
     }
 
     [Test]
-    public async Task CreateRequestMessageWithApiKey_WithKeyProvidedInQueryString_ReturnsExpectedResult()
+    public async Task CreateRequestMessageWithApiKey_WithKeyAndAdditionalParametersProvidedInQueryString_ReturnsExpectedResult()
     {
         // Arrange
         var serviceDetail = new ServiceDetail
@@ -48,7 +48,8 @@ internal class AuthorizedRequestBuilderTests : AuthorizedServiceTestsBase
             ApiKeyProvision = new ApiKeyProvision
             {
                 Key = "x-api-key",
-                Method = ApiKeyProvisionMethod.QueryString
+                Method = ApiKeyProvisionMethod.QueryString,
+                AdditionalParameters = new Dictionary<string, string> { { "foo", "bar" }, { "baz", "buzz" } }
             }
         };
         const string Path = "/api/test";
@@ -59,7 +60,7 @@ internal class AuthorizedRequestBuilderTests : AuthorizedServiceTestsBase
         HttpRequestMessage result = sut.CreateRequestMessageWithApiKey(serviceDetail, Path, HttpMethod.Post, "abc", data);
 
         // Assert
-        var expectedUri = new Uri("https://service.url/api/test?x-api-key=abc");
+        var expectedUri = new Uri("https://service.url/api/test?x-api-key=abc&foo=bar&baz=buzz");
         await AssertResult(result, expectedUri);
 
         result.Headers.Count().Should().Be(2);
@@ -67,7 +68,7 @@ internal class AuthorizedRequestBuilderTests : AuthorizedServiceTestsBase
     }
 
     [Test]
-    public async Task CreateRequestMessageWithApiKey_WithKeyProvidedInHttpHeader_ReturnsExpectedResult()
+    public async Task CreateRequestMessageWithApiKey_WithKeyAndAdditionalParametersProvidedInHttpHeader_ReturnsExpectedResult()
     {
         // Arrange
         var serviceDetail = new ServiceDetail
@@ -78,7 +79,8 @@ internal class AuthorizedRequestBuilderTests : AuthorizedServiceTestsBase
             ApiKeyProvision = new ApiKeyProvision
             {
                 Key = "x-api-key",
-                Method = ApiKeyProvisionMethod.HttpHeader
+                Method = ApiKeyProvisionMethod.HttpHeader,
+                AdditionalParameters = new Dictionary<string, string> { { "foo", "bar" }, { "baz", "buzz" } }
             }
         };
         const string Path = "/api/test";
@@ -92,8 +94,10 @@ internal class AuthorizedRequestBuilderTests : AuthorizedServiceTestsBase
         var expectedUri = new Uri("https://service.url/api/test");
         await AssertResult(result, expectedUri);
 
-        result.Headers.Count().Should().Be(3);
+        result.Headers.Count().Should().Be(5);
         result.Headers.Single(x => x.Key == "x-api-key").Value.First().Should().Be("abc");
+        result.Headers.Single(x => x.Key == "foo").Value.First().Should().Be("bar");
+        result.Headers.Single(x => x.Key == "baz").Value.First().Should().Be("buzz");
         AssertCommonHeaders(result);
     }
 

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "assemblyVersion": {
     "precision": "build"
   },


### PR DESCRIPTION
This addresses the issue raised in https://github.com/umbraco/Umbraco.AuthorizedServices/issues/37.

To Test:

- Verify updated unit tests are valid and pass.
- Briefly check and existing service that uses API key authorization just to make sure the change doesn't break anything.