### PR TITLE
Update Umbraco reference interval

### DIFF
--- a/src/Umbraco.AuthorizedServices/Umbraco.AuthorizedServices.csproj
+++ b/src/Umbraco.AuthorizedServices/Umbraco.AuthorizedServices.csproj
@@ -16,7 +16,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Umbraco.Cms.Web.BackOffice" Version="[10.0, 13)" />
+    <PackageReference Include="Umbraco.Cms.Web.BackOffice" Version="[10.0, 14)" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Tested the `Umbraco.AuthorizedServices` package with Umbraco 13 and services that cover all authentication methods got authorized successfully. 

Only update is the Umbraco version interval.