### PR TITLE
Updated size of token columns for new installs and upgrades.

### DIFF
--- a/src/Umbraco.AuthorizedServices/Constants.cs
+++ b/src/Umbraco.AuthorizedServices/Constants.cs
@@ -88,6 +88,8 @@ public static class Constants
                 public const string AddKeyTable = "authorizedServices-key-db";
 
                 public const string AddOAuth1TokenTable = "authorizedServices-oauth1_token-db";
+
+                public const string AlterTokenColumnLengths = "authorizedServices-alter-token-column-lengths-db";
             }
         }
     }

--- a/src/Umbraco.AuthorizedServices/Constants.cs
+++ b/src/Umbraco.AuthorizedServices/Constants.cs
@@ -74,6 +74,8 @@ public static class Constants
             public const string OAuth1Token = "umbracoAuthorizedServiceOAuth1Token";
         }
 
+        public const int TokenFieldSize = 5000;
+
         public static class Migrations
         {
 

--- a/src/Umbraco.AuthorizedServices/Migrations/AlterTokenColumnLengths.cs
+++ b/src/Umbraco.AuthorizedServices/Migrations/AlterTokenColumnLengths.cs
@@ -24,25 +24,25 @@ public class AlterTokenColumnLengths : MigrationBase
 
         Alter.Table(Constants.Database.TableNames.OAuth2Token)
             .AlterColumn("accessToken")
-            .AsString(2000)
+            .AsString(Constants.Database.TokenFieldSize)
             .NotNullable()
             .Do();
 
         Alter.Table(Constants.Database.TableNames.OAuth2Token)
             .AlterColumn("refreshToken")
-            .AsString(2000)
+            .AsString(Constants.Database.TokenFieldSize)
             .NotNullable()
             .Do();
 
         Alter.Table(Constants.Database.TableNames.OAuth1Token)
             .AlterColumn("oauthToken")
-            .AsString(2000)
+            .AsString(Constants.Database.TokenFieldSize)
             .NotNullable()
             .Do();
 
         Alter.Table(Constants.Database.TableNames.OAuth1Token)
             .AlterColumn("oauthTokenSecret")
-            .AsString(2000)
+            .AsString(Constants.Database.TokenFieldSize)
             .NotNullable()
             .Do();
     }

--- a/src/Umbraco.AuthorizedServices/Migrations/AlterTokenColumnLengths.cs
+++ b/src/Umbraco.AuthorizedServices/Migrations/AlterTokenColumnLengths.cs
@@ -1,0 +1,51 @@
+using Microsoft.Extensions.Logging;
+using Umbraco.Cms.Infrastructure.Migrations;
+using Umbraco.Cms.Infrastructure.Persistence;
+
+namespace Umbraco.AuthorizedServices.Migrations;
+
+public class AlterTokenColumnLengths : MigrationBase
+{
+    public AlterTokenColumnLengths(IMigrationContext context) : base(context)
+    {
+    }
+
+    protected override void Migrate()
+    {
+        Logger.LogDebug($"Running migration {nameof(AlterTokenColumnLengths)}");
+
+        // SQLite doesn't support alter table but fortunately the fields are variable text length anyway.
+        // So skip unless running on SQL Server.
+        if (IsSqlite(Database.SqlContext))
+        {
+            Logger.LogDebug($"Skipping altering udi field column lengths in Authorized Services tables as running on SQLite.");
+            return;
+        }
+
+        Alter.Table(Constants.Database.TableNames.OAuth2Token)
+            .AlterColumn("accessToken")
+            .AsString(2000)
+            .NotNullable()
+            .Do();
+
+        Alter.Table(Constants.Database.TableNames.OAuth2Token)
+            .AlterColumn("refreshToken")
+            .AsString(2000)
+            .NotNullable()
+            .Do();
+
+        Alter.Table(Constants.Database.TableNames.OAuth1Token)
+            .AlterColumn("oauthToken")
+            .AsString(2000)
+            .NotNullable()
+            .Do();
+
+        Alter.Table(Constants.Database.TableNames.OAuth1Token)
+            .AlterColumn("oauthTokenSecret")
+            .AsString(2000)
+            .NotNullable()
+            .Do();
+    }
+
+    private static bool IsSqlite(ISqlContext sqlContext) => Type.GetType("Umbraco.Cms.Persistence.Sqlite.Services.SqliteSyntaxProvider, Umbraco.Cms.Persistence.Sqlite") == sqlContext.SqlSyntax.GetType();
+}

--- a/src/Umbraco.AuthorizedServices/Migrations/AuthorizedServicesMigrationPlan.cs
+++ b/src/Umbraco.AuthorizedServices/Migrations/AuthorizedServicesMigrationPlan.cs
@@ -17,12 +17,15 @@ public class AuthorizedServicesMigrationPlan : PackageMigrationPlan
     /// <inheritdoc />
     protected override void DefinePlan()
     {
-        // 0.2
+        // 0.2.0
         To<AddOAuth2TokenTable>(Constants.Database.Migrations.TargetStates.AddOAuth2TokenTable);
 
-        // 0.3
+        // 0.3.0
         To<RenameOAuth2TokenTable>(Constants.Database.Migrations.TargetStates.RenameOAuth2TokenTable);
         To<AddKeyTable>(Constants.Database.Migrations.TargetStates.AddKeyTable);
         To<AddOAuth1TokenTable>(Constants.Database.Migrations.TargetStates.AddOAuth1TokenTable);
+
+        // 0.3.3
+        To<AlterTokenColumnLengths>(Constants.Database.Migrations.TargetStates.AlterTokenColumnLengths);
     }
 }

--- a/src/Umbraco.AuthorizedServices/Persistence/Dtos/OAuth1TokenDto.cs
+++ b/src/Umbraco.AuthorizedServices/Persistence/Dtos/OAuth1TokenDto.cs
@@ -14,10 +14,10 @@ public class OAuth1TokenDto
     public string ServiceAlias { get; set; } = string.Empty;
 
     [Column("oauthToken")]
-    [Length(1000)]
+    [Length(2000)]
     public string OAuthToken { get; set; } = string.Empty;
 
     [Column("oauthTokenSecret")]
-    [Length(1000)]
+    [Length(2000)]
     public string OAuthTokenSecret { get; set; } = string.Empty;
 }

--- a/src/Umbraco.AuthorizedServices/Persistence/Dtos/OAuth1TokenDto.cs
+++ b/src/Umbraco.AuthorizedServices/Persistence/Dtos/OAuth1TokenDto.cs
@@ -14,10 +14,10 @@ public class OAuth1TokenDto
     public string ServiceAlias { get; set; } = string.Empty;
 
     [Column("oauthToken")]
-    [Length(2000)]
+    [Length(Constants.Database.TokenFieldSize)]
     public string OAuthToken { get; set; } = string.Empty;
 
     [Column("oauthTokenSecret")]
-    [Length(2000)]
+    [Length(Constants.Database.TokenFieldSize)]
     public string OAuthTokenSecret { get; set; } = string.Empty;
 }

--- a/src/Umbraco.AuthorizedServices/Persistence/Dtos/OAuth2TokenDto.cs
+++ b/src/Umbraco.AuthorizedServices/Persistence/Dtos/OAuth2TokenDto.cs
@@ -15,11 +15,11 @@ public class OAuth2TokenDto
     public string ServiceAlias { get; set; } = string.Empty;
 
     [Column("accessToken")]
-    [Length(2000)]
+    [Length(Constants.Database.TokenFieldSize)]
     public string AccessToken { get; set; } = string.Empty;
 
     [Column("refreshToken")]
-    [Length(2000)]
+    [Length(Constants.Database.TokenFieldSize)]
     [NullSetting(NullSetting = NullSettings.Null)]
     public string? RefreshToken { get; set; }
 

--- a/src/Umbraco.AuthorizedServices/Persistence/Dtos/OAuth2TokenDto.cs
+++ b/src/Umbraco.AuthorizedServices/Persistence/Dtos/OAuth2TokenDto.cs
@@ -15,11 +15,11 @@ public class OAuth2TokenDto
     public string ServiceAlias { get; set; } = string.Empty;
 
     [Column("accessToken")]
-    [Length(1000)]
+    [Length(2000)]
     public string AccessToken { get; set; } = string.Empty;
 
     [Column("refreshToken")]
-    [Length(1000)]
+    [Length(2000)]
     [NullSetting(NullSetting = NullSettings.Null)]
     public string? RefreshToken { get; set; }
 

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "assemblyVersion": {
     "precision": "build"
   },


### PR DESCRIPTION
This PR should resolve issue https://github.com/umbraco/Umbraco.AuthorizedServices/issues/40 which has shown that 1000 characters wasn't sufficient to store access tokens from all services.  Here I've updated the size for new installs to 2000 characters, and added a migration to ensure that existing installs are updated with the larger field sizes.

To Test:

- Start up a website linked to the updated package code.
- Review the token columns in `umbracoAuthorizedServiceOAuth1Token` and `umbracoAuthorizedServiceOAuth2Token` and confirm they are now 2000 characters.