### PR TITLE
Changed tokensize from 5000 to 4000

### DIFF
--- a/src/Umbraco.AuthorizedServices/Constants.cs
+++ b/src/Umbraco.AuthorizedServices/Constants.cs
@@ -74,7 +74,7 @@ public static class Constants
             public const string OAuth1Token = "umbracoAuthorizedServiceOAuth1Token";
         }
 
-        public const int TokenFieldSize = 5000;
+        public const int TokenFieldSize = 4000;
 
         public static class Migrations
         {


### PR DESCRIPTION
Tokensize 5000 causes sqlexception on SqlServer V15

Microsoft.Data.SqlClient.SqlException (0x80131904): The size (5000) given to the parameter 'accessToken' exceeds the maximum allowed (4000).
   at Microsoft.Data.SqlClient.SqlConnection.OnError(SqlException exception, Boolean breakConnection, Action`1 wrapCloseInAction)
   at Microsoft.Data.SqlClient.SqlInternalConnection.OnError(SqlException exception, Boolean breakConnection, Action`1 wrapCloseInAction)
   at Microsoft.Data.SqlClient.TdsParser.ThrowExceptionAndWarning(TdsParserStateObject stateObj, Boolean callerHasConnectionLock, Boolean asyncClose)
   at Microsoft.Data.SqlClient.TdsParser.TryRun(RunBehavior runBehavior, SqlCommand cmdHandler, SqlDataReader dataStream, BulkCopySimpleResultSet bulkCopyHandler, TdsParserStateObject stateObj, Boolean& dataReady)
   at Microsoft.Data.SqlClient.SqlCommand.RunExecuteNonQueryTds(String methodName, Boolean isAsync, Int32 timeout, Boolean asyncWrite)
   at Microsoft.Data.SqlClient.SqlCommand.InternalExecuteNonQuery(TaskCompletionSource`1 completion, Boolean sendToPipe, Int32 timeout, Boolean& usedCache, Boolean asyncWrite, Boolean inRetry, String methodName)
   at Microsoft.Data.SqlClient.SqlCommand.ExecuteNonQuery()
   at StackExchange.Profiling.Data.ProfiledDbCommand.ExecuteNonQuery() in C:\projects\dotnet\src\MiniProfiler.Shared\Data\ProfiledDbCommand.cs:line 261
   at Umbraco.Cms.Infrastructure.Persistence.FaultHandling.FaultHandlingDbCommand.<ExecuteNonQuery>b__32_0()
   at Umbraco.Cms.Infrastructure.Persistence.FaultHandling.FaultHandlingDbCommand.<>c__DisplayClass38_0`1.<Execute>b__0()
   at Umbraco.Cms.Infrastructure.Persistence.FaultHandling.RetryPolicy.ExecuteAction[TResult](Func`1 func)
   at Umbraco.Cms.Infrastructure.Persistence.FaultHandling.FaultHandlingDbCommand.Execute[T](Func`1 f)
   at Umbraco.Cms.Infrastructure.Persistence.FaultHandling.FaultHandlingDbCommand.ExecuteNonQuery()
   at NPoco.Database.<>c__DisplayClass296_0.<ExecuteNonQueryHelper>b__0()
   at NPoco.Database.ExecutionHook[T](Func`1 action)
   at NPoco.Database.ExecuteNonQueryHelper(DbCommand cmd)
   at NPoco.Database.Execute(String sql, CommandType commandType, Object[] args)
   at NPoco.Database.Execute(Sql Sql)
   at Umbraco.Cms.Persistence.SqlServer.Services.MicrosoftSqlSyntaxProviderBase`1.HandleCreateTable(IDatabase database, TableDefinition tableDefinition, Boolean skipKeysAndIndexes)
   at Umbraco.Cms.Infrastructure.Migrations.Expressions.Create.Table.CreateTableOfDtoBuilder.Do()
   at Umbraco.AuthorizedServices.Migrations.AddOAuth2TokenTable.Migrate()
   at Umbraco.Cms.Infrastructure.Migrations.MigrationBase.Run()
   at Umbraco.Cms.Infrastructure.Migrations.MigrationPlanExecutor.RunMigration(Type migrationType, MigrationContext context)
   at Umbraco.Cms.Infrastructure.Migrations.MigrationPlanExecutor.RunScopedMigration(Type migrationType, MigrationPlan plan)
   at Umbraco.Cms.Infrastructure.Migrations.MigrationPlanExecutor.RunMigrationPlan(MigrationPlan plan, String fromState)
ClientConnectionId:129659e0-0a63-4300-a2a2-209c89c4edac
Error Number:2717,State:2,Class:16