### PR TITLE
Added abstraction for creation of HTTP clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -434,6 +434,10 @@ Responsible for defining the operations building the dictionary of parameters us
 
 Responsible for making requests to the authorized services for the purposes of accessing business functionality. This is used by Umbraco solution developers and is described in detail above. Implemented by `AuthorizedServiceCaller`.
 
+#### IAuthorizedServiceHttpClientFactory
+
+Responsible for constructing an HTTP client used for making requests to the authorized service. Implemented by `AuthorizedServiceHttpClientFactory`.
+
 #### IRefreshTokenParametersBuilder
 
 Responsible for creating a dictionary of parameters provided in the request to retrieve an access token from a refresh token. Implemented by `RefreshTokenParametersBuilder`.

--- a/src/Umbraco.AuthorizedServices/AuthorizedServicesComposer.cs
+++ b/src/Umbraco.AuthorizedServices/AuthorizedServicesComposer.cs
@@ -47,6 +47,7 @@ internal class AuthorizedServicesComposer : IComposer
         builder.Services.AddUnique<IAuthorizedServiceAuthorizer, AuthorizedServiceAuthorizer>();
         builder.Services.AddUnique<IAuthorizationUrlBuilder, AuthorizationUrlBuilder>();
         builder.Services.AddUnique<IAuthorizedRequestBuilder, AuthorizedRequestBuilder>();
+        builder.Services.AddUnique<IAuthorizedServiceHttpClientFactory, AuthorizedServiceHttpClientFactory>();
 
         builder.Services.AddUnique<IAuthorizedServiceCaller, AuthorizedServiceCaller>();
         builder.Services.AddUnique<IServiceResponseMetadataParser, ServiceResponseMetadataParser>();

--- a/src/Umbraco.AuthorizedServices/Services/IAuthorizedServiceHttpClientFactory.cs
+++ b/src/Umbraco.AuthorizedServices/Services/IAuthorizedServiceHttpClientFactory.cs
@@ -1,0 +1,11 @@
+using Umbraco.AuthorizedServices.Configuration;
+
+namespace Umbraco.AuthorizedServices.Services;
+
+/// <summary>
+/// Defines operations on creation of HTTP clients for authorized services.
+/// </summary>
+public interface IAuthorizedServiceHttpClientFactory
+{
+    HttpClient CreateClient(ServiceDetail serviceDetail, string path, HttpMethod httpMethod);
+}

--- a/src/Umbraco.AuthorizedServices/Services/Implement/AuthorizedServiceCaller.cs
+++ b/src/Umbraco.AuthorizedServices/Services/Implement/AuthorizedServiceCaller.cs
@@ -13,7 +13,7 @@ namespace Umbraco.AuthorizedServices.Services.Implement;
 
 internal sealed class AuthorizedServiceCaller : AuthorizedServiceBase, IAuthorizedServiceCaller
 {
-    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly IAuthorizedServiceHttpClientFactory _httpClientFactory;
     private readonly JsonSerializerFactory _jsonSerializerFactory;
     private readonly IAuthorizedRequestBuilder _authorizedRequestBuilder;
     private readonly IRefreshTokenParametersBuilder _refreshTokenParametersBuilder;
@@ -30,7 +30,7 @@ internal sealed class AuthorizedServiceCaller : AuthorizedServiceBase, IAuthoriz
         IAuthorizationRequestSender authorizationRequestSender,
         ILogger<AuthorizedServiceCaller> logger,
         IOptionsMonitor<ServiceDetail> serviceDetailOptions,
-        IHttpClientFactory httpClientFactory,
+        IAuthorizedServiceHttpClientFactory httpClientFactory,
         JsonSerializerFactory jsonSerializerFactory,
         IAuthorizedRequestBuilder authorizedRequestBuilder,
         IRefreshTokenParametersBuilder refreshTokenParametersBuilder,
@@ -100,8 +100,6 @@ internal sealed class AuthorizedServiceCaller : AuthorizedServiceBase, IAuthoriz
     {
         ServiceDetail serviceDetail = GetServiceDetail(serviceAlias);
 
-        HttpClient httpClient = _httpClientFactory.CreateClient();
-
         Attempt<HttpRequestMessage?> requestMessageAttempt = await CreateHttpRequestMessage(serviceDetail, path, httpMethod, requestContent);
         if (!requestMessageAttempt.Success)
         {
@@ -109,6 +107,8 @@ internal sealed class AuthorizedServiceCaller : AuthorizedServiceBase, IAuthoriz
                 new AuthorizedServiceResponse<string>(),
                 requestMessageAttempt.Exception!)!;
         }
+
+        HttpClient httpClient = _httpClientFactory.CreateClient(serviceDetail, path, httpMethod);
 
         HttpResponseMessage response = await httpClient.SendAsync(requestMessageAttempt.Result!);
 

--- a/src/Umbraco.AuthorizedServices/Services/Implement/AuthorizedServiceHttpClientFactory.cs
+++ b/src/Umbraco.AuthorizedServices/Services/Implement/AuthorizedServiceHttpClientFactory.cs
@@ -1,0 +1,12 @@
+using Umbraco.AuthorizedServices.Configuration;
+
+namespace Umbraco.AuthorizedServices.Services.Implement;
+
+internal sealed class AuthorizedServiceHttpClientFactory : IAuthorizedServiceHttpClientFactory
+{
+    private readonly IHttpClientFactory _httpClientFactory;
+
+    public AuthorizedServiceHttpClientFactory(IHttpClientFactory httpClientFactory) => _httpClientFactory = httpClientFactory;
+
+    public HttpClient CreateClient(ServiceDetail serviceDetail, string path, HttpMethod httpMethod) => _httpClientFactory.CreateClient();
+}

--- a/tests/Umbraco.AuthorizedServices.Tests/Services/AuthorizedServiceCallerTests.cs
+++ b/tests/Umbraco.AuthorizedServices.Tests/Services/AuthorizedServiceCallerTests.cs
@@ -376,7 +376,7 @@ internal class AuthorizedServiceCallerTests : AuthorizedServiceTestsBase
             authorizationRequestSenderMock.Object,
             new NullLogger<AuthorizedServiceCaller>(),
             optionsMonitorServiceDetailMock.Object,
-            new TestHttpClientFactory(statusCode, responseContent),
+            new AuthorizedServiceHttpClientFactory(new TestHttpClientFactory(statusCode, responseContent)),
             factory,
             new AuthorizedRequestBuilder(factory),
             new RefreshTokenParametersBuilder(),

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "10.1.1",
+  "version": "10.2.0",
   "assemblyVersion": {
     "precision": "build"
   },


### PR DESCRIPTION
This PR provides a solution to the issue raised here: https://github.com/umbraco/Umbraco.AuthorizedServices/issues/57

I went with the final suggestion of providing an abstraction around the creation of HTTP clients rather than just using `IHttpClientFactory` directly.  There's a new interface now, injected into `AuthorizedServiceCaller` that an implementor can override if they want to do something other than the default functionality provided by the package.

The method provided for creating a client takes information about the service being requested and the request itself, in order to allow for custom creation (e.g. different headers for different services and requests).

I've targeted this PR to the V10 version (which works up from Umbraco 10 to 13) and bumped the version to 10.2.  Once approved, it can be merged up to the `main` branch and released for Umbraco 15 too.

// @jamiepollock @dawoe if you'd like to have a look over, @acoumb for internal review and release.